### PR TITLE
Avoid redundant logging when included in another codebase

### DIFF
--- a/sllurp/test.py
+++ b/sllurp/test.py
@@ -8,8 +8,6 @@ import binascii
 import logging
 
 logLevel = logging.WARNING
-logging.basicConfig(level=logLevel,
-        format='%(asctime)s %(name)s: %(levelname)s: %(message)s')
 logger = logging.getLogger('sllurp')
 logger.setLevel(logLevel)
 
@@ -174,4 +172,6 @@ class TestEncodings (unittest.TestCase):
         self.assertEqual(flags, 0b0001011110)
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logLevel,
+        format='%(asctime)s %(name)s: %(levelname)s: %(message)s')
     unittest.main()


### PR DESCRIPTION
My first (tiny) PR. :dancers: 
