### PR TITLE
Added reader presets for R1000 and R420

### DIFF
--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -226,10 +226,14 @@ Modulation_Name2Type = {
     'M8': 3,
     'WISP5pre': 0,
     'WISP5': 0,
+    'R1000': 0,
+    'R420': 0,
 }
 Modulation_DefaultTari = {
     'WISP5pre': 12500,
     'WISP5': 6250,
+    'R1000': 7140,
+    'R420': 6250,
 }
 DEFAULT_MODULATION = 'M4'
 


### PR DESCRIPTION
Added default reader presets which can be used for the Impinj R1000 and R420 readers.