### PR TITLE
Add support for BlockWrite.

### DIFF
--- a/sllurp/access.py
+++ b/sllurp/access.py
@@ -30,14 +30,24 @@ def access (proto):
 
     writeSpecParam = None
     if args.write_words:
-        writeSpecParam = {
-            'OpSpecID': 0,
-            'MB': 3,
-            'WordPtr': 0,
-            'AccessPassword': 0,
-            'WriteDataWordCount': args.write_words,
-            'WriteData': '\xbe\xef', # XXX allow user-defined pattern
-        }
+        if args.write_words > 1:
+            writeSpecParam = {
+                'OpSpecID': 0,
+                'MB': 3,
+                'WordPtr': 0,
+                'AccessPassword': 0,
+                'WriteDataWordCount': args.write_words,
+                'WriteData': '\xde\xad\xbe\xef', # XXX allow user-defined pattern
+            }
+        else:
+            writeSpecParam = {
+                'OpSpecID': 0,
+                'MB': 3,
+                'WordPtr': 0,
+                'AccessPassword': 0,
+                'WriteDataWordCount': args.write_words,
+                'WriteData': '\xbe\xef', # XXX allow user-defined pattern
+            }
 
     return proto.startAccess(readWords=readSpecParam,
             writeWords=writeSpecParam)

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -1591,7 +1591,10 @@ def encode_AccessCommand (par):
     data = encode_C1G2TagSpec(par['TagSpecParameter'])
 
     if 'WriteData' in par['OpSpecParameter']:
-        data += encode_C1G2Write(par['OpSpecParameter'])
+        if par['OpSpecParameter']['WriteDataWordCount'] > 1:
+            data += encode_C1G2BlockWrite(par['OpSpecParameter'])
+        else:
+            data += encode_C1G2Write(par['OpSpecParameter'])
     else:
         data += encode_C1G2Read(par['OpSpecParameter'])
 
@@ -1725,6 +1728,37 @@ def encode_C1G2Write (par):
 
 Message_struct['C1G2Write'] = {
     'type': 342,
+    'fields': [
+        'Type',
+        'OpSpecID',
+        'MB',
+        'WordPtr',
+        'AccessPassword'
+        'WriteDataWordCount',
+        'WriteData'
+    ],
+    'encode': encode_C1G2Write
+}
+
+# 16.2.1.3.2.7 C1G2BlockWrite
+def encode_C1G2BlockWrite (par):
+    msgtype = Message_struct['C1G2BlockWrite']['type']
+    msg_header = '!HH'
+    msg_header_len = struct.calcsize(msg_header)
+
+    data = struct.pack('!H', int(par['OpSpecID']))
+    data += struct.pack('!I', int(par['AccessPassword']))
+    data += struct.pack('!B', int(par['MB']) << 6)
+    data += struct.pack('!H', int(par['WordPtr']))
+    data += struct.pack('!H', int(par['WriteDataWordCount']))
+    data += par['WriteData']
+
+    data = struct.pack(msg_header, msgtype,
+            len(data) + msg_header_len) + data
+    return data
+
+Message_struct['C1G2BlockWrite'] = {
+    'type': 347,
     'fields': [
         'Type',
         'OpSpecID',


### PR DESCRIPTION
This pull request allows SLLURP to add BlockWrite commands to the AccessSpec (previously it was just using Write even though multiple words were written).
Tested using a commercial tag and working!