### PR TITLE
Include 'tags/second' rate in shutdown message

### DIFF
--- a/sllurp/access.py
+++ b/sllurp/access.py
@@ -7,13 +7,31 @@ from twisted.internet import reactor, defer
 
 import sllurp.llrp as llrp
 
+startTime = None
+endTime = None
+
 tagReport = 0
 logger = logging.getLogger('sllurp')
 
 args = None
 
+def startTimeMeasurement():
+    global startTime
+    startTime = time.time()
+
+def stopTimeMeasurement():
+    global endTime
+    endTime = time.time()
+
 def finish (_):
-    logger.info('total # of tags seen: %d', tagReport)
+    global startTime
+    global endTime
+
+    # stop runtime measurement to determine rates
+    stopTimeMeasurement()
+    runTime = (endTime - startTime) if (endTime > startTime) else 0
+
+    logger.info('total # of tags seen: %d (%d tags/second)', tagReport, tagReport/runTime)
     if reactor.running:
         reactor.stop()
 
@@ -161,6 +179,9 @@ def main ():
 
     # catch ctrl-C and stop inventory before disconnecting
     reactor.addSystemEventTrigger('before', 'shutdown', politeShutdown, fac)
+
+    # start runtime measurement to determine rates
+    startTimeMeasurement()
 
     reactor.run()
 

--- a/sllurp/inventory.py
+++ b/sllurp/inventory.py
@@ -9,13 +9,31 @@ import sllurp.llrp as llrp
 from sllurp.llrp_proto import Modulation_Name2Type, DEFAULT_MODULATION, \
      Modulation_DefaultTari
 
+startTime = None
+endTime = None
+
 numTags = 0
 logger = logging.getLogger('sllurp')
 
 args = None
 
+def startTimeMeasurement():
+    global startTime
+    startTime = time.time()
+
+def stopTimeMeasurement():
+    global endTime
+    endTime = time.time()
+
 def finish (_):
-    logger.info('total # of tags seen: %d', numTags)
+    global startTime
+    global endTime
+
+    # stop runtime measurement to determine rates
+    stopTimeMeasurement()
+    runTime = (endTime - startTime) if (endTime > startTime) else 0
+
+    logger.info('total # of tags seen: %d (%d tags/second)', numTags, numTags/runTime)
     if reactor.running:
         reactor.stop()
 
@@ -141,6 +159,9 @@ def main ():
 
     # catch ctrl-C and stop inventory before disconnecting
     reactor.addSystemEventTrigger('before', 'shutdown', politeShutdown, fac)
+
+    # start runtime measurement to determine rates
+    startTimeMeasurement()
 
     reactor.run()
 


### PR DESCRIPTION
Hi Ben,

With these changes SLLURP will print the *number of tags seen* normalized to the runtime i.e. the rate of tags.

We have been using these changes for a while now in Delft. Might be a nice addition for other people too.

--Ivar