### PR TITLE
Access operations minor bugfix & enhancements (R/W and C1G2 Lock)

### DIFF
--- a/bin/lock
+++ b/bin/lock
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# default Python interpreter is 'python' from your $PATH; set the $PYTHON
+# environment variable to override it
+: ${PYTHON:=python}
+export PYTHONPATH="$(dirname $0)/..:$PYTHONPATH"
+
+exec "$PYTHON" -m sllurp.lock ${1+"$@"}

--- a/sllurp/access.py
+++ b/sllurp/access.py
@@ -45,9 +45,9 @@ def access(proto):
     if args.read_words:
         readSpecParam = {
             'OpSpecID': 0,
-            'MB': 3,
-            'WordPtr': 0,
-            'AccessPassword': 0,
+            'MB': args.mb,
+            'WordPtr': args.word_ptr,
+            'AccessPassword': args.access_password,
             'WordCount': args.read_words
         }
 
@@ -56,18 +56,18 @@ def access(proto):
         if args.write_words > 1:
             writeSpecParam = {
                 'OpSpecID': 0,
-                'MB': 3,
-                'WordPtr': 0,
-                'AccessPassword': 0,
+                'MB': args.mb,
+                'WordPtr': args.word_ptr,
+                'AccessPassword':  args.access_password,
                 'WriteDataWordCount': args.write_words,
                 'WriteData': '\xde\xad\xbe\xef',  # XXX allow user-def pattern
             }
         else:
             writeSpecParam = {
                 'OpSpecID': 0,
-                'MB': 3,
-                'WordPtr': 0,
-                'AccessPassword': 0,
+                'MB': args.mb,
+                'WordPtr': args.word_ptr,
+                'AccessPassword':  args.access_password,
                 'WriteDataWordCount': args.write_words,
                 'WriteData': '\xbe\xef',  # XXX allow user-defined pattern
             }
@@ -91,7 +91,6 @@ def tagReportCallback(llrpMsg):
         return
     for tag in tags:
         tagReport += tag['TagSeenCount'][0]
-
 
 def parse_args():
     global args
@@ -123,9 +122,22 @@ def parse_args():
     # read or write
     op = parser.add_mutually_exclusive_group(required=True)
     op.add_argument('-r', '--read-words', type=int,
-                    help='Number of words to read from MB 0 WordPtr 0')
+                    help='Number of words to read')
     op.add_argument('-w', '--write-words', type=int,
-                    help='Number of words to write to MB 0 WordPtr 0')
+                    help='Number of words to write')
+
+    # C1G2 Read / Write parameters:
+    parser.add_argument('-mb', '--memory-bank', default=3, type=int,
+                        dest='mb',
+                        help='Memory bank: 3 User, 2 TID, 1 EPC, 0 Reserved')
+    parser.add_argument('-wp', '--word-ptr', default=3, type=int,
+                        dest='word_ptr',
+                        help='Word addresss of the first word to read/write')
+
+    parser.add_argument('-ap', '--access_password', default=0, type=int,
+                        dest='access_password',
+                        help='Access password for secure state if R/W locked')
+
     parser.add_argument('-l', '--logfile')
 
     args = parser.parse_args()

--- a/sllurp/llrp.py
+++ b/sllurp/llrp.py
@@ -680,14 +680,10 @@ class LLRPClient(LineReceiver):
         else:
             raise LLRPError('startAccess requires readWords or writeWords.')
 
-        if accessStopParam:
-            opSpecParam['AccessSpecStopTriggerType'] = \
-                accessStopParam['AccessSpecStopTriggerType']
-            opSpecParam['OperationCountValue'] = \
-                accessStopParam['OperationCountValue']
-        else:
-            opSpecParam['AccessSpecStopTriggerType'] = 1
-            opSpecParam['OperationCountValue'] = 5
+        if not accessStopParam:
+            accessStopParam = {}
+            accessStopParam['AccessSpecStopTriggerType'] = 1
+            accessStopParam['OperationCountValue'] = 5
 
         accessSpec = {
             'Type': m['type'],

--- a/sllurp/llrp.py
+++ b/sllurp/llrp.py
@@ -646,7 +646,8 @@ class LLRPClient(LineReceiver):
                         accessSpecID=accessSpecID)
 
     def startAccess(self, readWords=None, writeWords=None, target=None,
-                    accessStopParam=None, accessSpecID=1, *args):
+                    accessStopParam=None, accessSpecID=1, param=None,
+                    *args):
         m = Message_struct['AccessSpec']
         if not target:
             target = {
@@ -677,6 +678,11 @@ class LLRPClient(LineReceiver):
             opSpecParam['WriteData'] = writeWords['WriteData']
             if 'OpSpecID' in writeWords:
                 opSpecParam['OpSpecID'] = writeWords['OpSpecID']
+
+        elif param:
+            # special parameters like C1G2Lock
+            opSpecParam = param
+
         else:
             raise LLRPError('startAccess requires readWords or writeWords.')
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -1623,6 +1623,8 @@ def encode_AccessCommand(par):
             data += encode_C1G2BlockWrite(par['OpSpecParameter'])
         else:
             data += encode_C1G2Write(par['OpSpecParameter'])
+    elif 'LockPayload' in par['OpSpecParameter']:
+        data += encode_C1G2Lock(par['OpSpecParameter'])
     else:
         data += encode_C1G2Read(par['OpSpecParameter'])
 
@@ -1773,6 +1775,56 @@ Message_struct['C1G2Write'] = {
     'encode': encode_C1G2Write
 }
 
+
+# 16.2.1.3.2.5 C1G2Lock Parameter
+def encode_C1G2Lock(par):
+    msgtype = Message_struct['C1G2Lock']['type']
+    msg_header = '!HH'
+    msg_header_len = struct.calcsize(msg_header)
+
+    data = struct.pack('!H', int(par['OpSpecID']))
+    data += struct.pack('!I', int(par['AccessPassword']))
+    for payload in par['LockPayload']:
+        data += encode_C1G2LockPayload(payload)
+
+    data = struct.pack(msg_header, msgtype,
+                       len(data) + msg_header_len) + data
+    return data
+
+Message_struct['C1G2Lock'] = {
+    'type': 344,
+    'fields': [
+        'Type',
+        'OpSpecID',
+        'LockCommandPayloadList',
+        'AccessPassword'
+    ],
+    'encode': encode_C1G2Lock
+}
+
+# 16.2.1.3.2.5.1 C1G2LockPayload Parameter
+def encode_C1G2LockPayload(par):
+    msgtype = Message_struct['C1G2LockPayload']['type']
+    msg_header = '!HH'
+    msg_header_len = struct.calcsize(msg_header)
+
+    data = struct.pack('!B', int(par['Privilege']))
+    data += struct.pack('!b', int(par['DataField']))
+
+    data = struct.pack(msg_header, msgtype,
+                       len(data) + msg_header_len) + data
+    return data
+
+Message_struct['C1G2LockPayload'] = {
+    'type': 345,
+    'fields': [
+        'Type',
+        'OpSpecID',
+        'Privilege',
+        'DataField',
+    ],
+    'encode': encode_C1G2LockPayload
+}
 
 # 16.2.1.3.2.7 C1G2BlockWrite
 def encode_C1G2BlockWrite(par):

--- a/sllurp/lock.py
+++ b/sllurp/lock.py
@@ -1,0 +1,191 @@
+from __future__ import print_function
+import argparse
+import logging
+import pprint
+import time
+from twisted.internet import reactor, defer
+
+import sllurp.llrp as llrp
+
+startTime = None
+endTime = None
+
+tagReport = 0
+logger = logging.getLogger('sllurp')
+
+args = None
+
+
+def startTimeMeasurement():
+    global startTime
+    startTime = time.time()
+
+
+def stopTimeMeasurement():
+    global endTime
+    endTime = time.time()
+
+
+def finish(_):
+    global startTime
+    global endTime
+
+    # stop runtime measurement to determine rates
+    stopTimeMeasurement()
+    runTime = (endTime - startTime) if (endTime > startTime) else 0
+
+    logger.info('total # of tags seen: %d (%d tags/second)', tagReport,
+                tagReport/runTime)
+    if reactor.running:
+        reactor.stop()
+
+
+def access(proto):
+    lockSpecParam = {
+            'OpSpecID': 0,
+            'AccessPassword': args.access_password,
+            'LockPayload': [
+                {
+                    'Privilege': args.privilege,
+                    'DataField': args.data_field,
+                },
+            ]
+        }
+
+    return proto.startAccess(param=lockSpecParam)
+
+
+def politeShutdown(factory):
+    return factory.politeShutdown()
+
+
+def tagReportCallback(llrpMsg):
+    """Function to run each time the reader reports seeing tags."""
+    global tagReport
+    tags = llrpMsg.msgdict['RO_ACCESS_REPORT']['TagReportData']
+    if len(tags):
+        logger.info('saw tag(s): %s', pprint.pformat(tags))
+    else:
+        logger.info('no tags seen')
+        return
+    for tag in tags:
+        tagReport += tag['TagSeenCount'][0]
+        if "OpSpecResult" in tag:
+            result = tag["OpSpecResult"].get("Result")
+            logger.debug("result: %s", result)
+
+def parse_args():
+    global args
+    parser = argparse.ArgumentParser(description='Simple RFID Lock')
+    parser.add_argument('host', help='hostname or IP address of RFID reader',
+                        nargs='*')
+    parser.add_argument('-p', '--port', default=llrp.LLRP_PORT, type=int,
+                        help='port (default {})'.format(llrp.LLRP_PORT))
+    parser.add_argument('-t', '--time', default=10, type=float,
+                        help='number of seconds to inventory (default 10)')
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='show debugging output')
+    parser.add_argument('-n', '--report-every-n-tags', default=1, type=int,
+                        dest='every_n', metavar='N',
+                        help='issue a TagReport every N tags')
+    parser.add_argument('-X', '--tx-power', default=0, type=int,
+                        dest='tx_power',
+                        help='Transmit power (default 0=max power)')
+    parser.add_argument('-M', '--modulation', default='M8',
+                        help='modulation (default M8)')
+    parser.add_argument('-T', '--tari', default=0, type=int,
+                        help='Tari value (default 0=auto)')
+    parser.add_argument('-s', '--session', default=2, type=int,
+                        help='Gen2 session (default 2)')
+    parser.add_argument('-P', '--tag-population', default=4, type=int,
+                        dest='population',
+                        help='Tag Population value (default 4)')
+
+    # C1G2 Lock Payload parameters:
+    parser.add_argument('-priv', '--privilege', default=0, type=int,
+                        help='Access privilege: '
+                             '0 RW, 1 Permalock, 2 Permaunlock, 3 Unlock')
+    parser.add_argument('-df', '--data-field', default=0, type=int,
+                        dest='data_field',
+                        help='Access Data Field: 0 KILL passwd, '
+                             '1 ACCESS passwd, 2 EPC, 3 TID, 4 User memory')
+
+    parser.add_argument('-ap', '--access_password', default=0, type=int,
+                        dest='access_password',
+                        help='Access password for secure state if R/W locked')
+
+    parser.add_argument('-l', '--logfile')
+
+    args = parser.parse_args()
+
+
+def init_logging():
+    logLevel = (args.debug and logging.DEBUG or logging.INFO)
+    logFormat = '%(asctime)s %(name)s: %(levelname)s: %(message)s'
+    formatter = logging.Formatter(logFormat)
+    stderr = logging.StreamHandler()
+    stderr.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.setLevel(logLevel)
+    root.handlers = [stderr]
+
+    if args.logfile:
+        fHandler = logging.FileHandler(args.logfile)
+        fHandler.setFormatter(formatter)
+        root.addHandler(fHandler)
+
+    logger.log(logLevel, 'log level: %s', logging.getLevelName(logLevel))
+
+
+def main():
+    parse_args()
+    init_logging()
+
+    # will be called when all connections have terminated normally
+    onFinish = defer.Deferred()
+    onFinish.addCallback(finish)
+
+    fac = llrp.LLRPClientFactory(onFinish=onFinish,
+                                 disconnect_when_done=True,
+                                 modulation=args.modulation,
+                                 tari=args.tari,
+                                 session=args.session,
+                                 tag_population=args.population,
+                                 start_inventory=True,
+                                 tx_power=args.tx_power,
+                                 report_every_n_tags=args.every_n,
+                                 tag_content_selector={
+                                     'EnableROSpecID': False,
+                                     'EnableSpecIndex': False,
+                                     'EnableInventoryParameterSpecID': False,
+                                     'EnableAntennaID': True,
+                                     'EnableChannelIndex': False,
+                                     'EnablePeakRRSI': True,
+                                     'EnableFirstSeenTimestamp': False,
+                                     'EnableLastSeenTimestamp': True,
+                                     'EnableTagSeenCount': True,
+                                     'EnableAccessSpecID': True,
+                                 })
+
+    # tagReportCallback will be called every time the reader sends a TagReport
+    # message (i.e., when it has "seen" tags).
+    fac.addTagReportCallback(tagReportCallback)
+
+    # start tag access once inventorying
+    fac.addStateCallback(llrp.LLRPClient.STATE_INVENTORYING, access)
+
+    for host in args.host:
+        reactor.connectTCP(host, args.port, fac, timeout=3)
+
+    # catch ctrl-C and stop inventory before disconnecting
+    reactor.addSystemEventTrigger('before', 'shutdown', politeShutdown, fac)
+
+    # start runtime measurement to determine rates
+    startTimeMeasurement()
+
+    reactor.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Some initial changes to work in secured state & with access privilege updates (read/write/permalock):

 * Fixed access.py cli tool bug with the default stop trigger dict that raised an exception
 * Added command line args (--mb --word_ptr --access_password) to access.py cli tool
 * Added standard input/output support (to read/write tag data) in access.py cli tool
 * Implemented C1G2 Lock & LockPayload (including new lock.py cli tool with --privilege and --data-field args)

Now, the standalone command line tools are fully functional to set the kill/access password and lock/unlock the memory banks (at least for testing purposes, without needing to hard-code values in the scripts).