### PR TITLE
Minor fixes for access operations

### DIFF
--- a/sllurp/access.py
+++ b/sllurp/access.py
@@ -137,7 +137,7 @@ def parse_args():
     parser.add_argument('-mb', '--memory-bank', default=3, type=int,
                         dest='mb',
                         help='Memory bank: 3 User, 2 TID, 1 EPC, 0 Reserved')
-    parser.add_argument('-wp', '--word-ptr', default=3, type=int,
+    parser.add_argument('-wp', '--word-ptr', default=0, type=int,
                         dest='word_ptr',
                         help='Word addresss of the first word to read/write')
 

--- a/sllurp/llrp.py
+++ b/sllurp/llrp.py
@@ -670,6 +670,8 @@ class LLRPClient(LineReceiver):
             opSpecParam['WordCount'] = readWords['WordCount']
             if 'OpSpecID' in readWords:
                 opSpecParam['OpSpecID'] = readWords['OpSpecID']
+            if 'AccessPassword' in readWords:
+                opSpecParam['AccessPassword'] = readWords['AccessPassword']
 
         elif writeWords:
             opSpecParam['MB'] = writeWords['MB']
@@ -678,6 +680,8 @@ class LLRPClient(LineReceiver):
             opSpecParam['WriteData'] = writeWords['WriteData']
             if 'OpSpecID' in writeWords:
                 opSpecParam['OpSpecID'] = writeWords['OpSpecID']
+            if 'AccessPassword' in writeWords:
+                opSpecParam['AccessPassword'] = writeWords['AccessPassword']
 
         elif param:
             # special parameters like C1G2Lock


### PR DESCRIPTION
There is a bug that prevents using Access Password (neither using `access.py` or `llrp.py` directly). Without the fix, a locked memory bank cannot be read or written.

Also, I'd introduced a wrong default value for the word pointer command line argument in `access.py` that is not intuitive.
The patch provides a saner default to start reading/write from the beginning of the memory bank.
