### PR TITLE
Preliminary Python 3 fixes

### DIFF
--- a/sllurp/__init__.py
+++ b/sllurp/__init__.py
@@ -1,6 +1,7 @@
 """Low Level Reader Protocol implemtnation in pure Python
 """
 
+from __future__ import unicode_literals
 from pkg_resources import get_distribution
 
 

--- a/sllurp/__main__.py
+++ b/sllurp/__main__.py
@@ -1,6 +1,7 @@
 """sllurp command-line wrapper
 """
 
+from __future__ import unicode_literals
 from .cli import cli
 
 if __name__ == '__main__':

--- a/sllurp/access.py
+++ b/sllurp/access.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
 import binascii
 import logging

--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -1,7 +1,7 @@
 """Command-line wrapper for sllurp commands.
 """
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 from collections import namedtuple
 import logging
 import click

--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -60,7 +60,6 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
                 mode_identifier=mode_identifier,
                 reconnect=reconnect)
     logger.debug('inventory args: %s', args)
-    print(args.time)
     _inventory.main(args)
 
 

--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -10,6 +10,8 @@ from .verb import reset as _reset
 from .verb import inventory as _inventory
 from .llrp_proto import Modulation_Name2Type
 
+# Disable Click unicode warning since we use unicode string exclusively
+click.disable_unicode_literals_warning = True
 
 logger = logging.getLogger(__name__)
 mods = sorted(Modulation_Name2Type.keys())
@@ -58,6 +60,7 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
                 mode_identifier=mode_identifier,
                 reconnect=reconnect)
     logger.debug('inventory args: %s', args)
+    print(args.time)
     _inventory.main(args)
 
 

--- a/sllurp/csv_recorder.py
+++ b/sllurp/csv_recorder.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
 import csv
 import logging

--- a/sllurp/decode.py
+++ b/sllurp/decode.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import binascii
 import argparse
 import logging

--- a/sllurp/llrp.py
+++ b/sllurp/llrp.py
@@ -10,7 +10,7 @@ from .llrp_proto import LLRPROSpec, LLRPError, Message_struct, \
     DEFAULT_MODULATION
 from .llrp_errors import ReaderConfigurationError
 from binascii import hexlify
-from util import BITMASK, natural_keys
+from .util import BITMASK, natural_keys
 from twisted.internet import reactor, task, defer
 from twisted.internet.protocol import ClientFactory
 from twisted.protocols.basic import LineReceiver

--- a/sllurp/llrp.py
+++ b/sllurp/llrp.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 from collections import defaultdict
 import time
 import logging

--- a/sllurp/llrp_decoder.py
+++ b/sllurp/llrp_decoder.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import struct
 import logging
 

--- a/sllurp/llrp_errors.py
+++ b/sllurp/llrp_errors.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 __all__ = [
     # Exceptions
     "LLRPError",

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -717,11 +717,11 @@ def decode_ROAccessReport(data):
     # Decode parameters
     msg['TagReportData'] = []
     while True:
-        try:
-            ret, data = decode('TagReportData')(data)
-        except TypeError:  # XXX
-            logger.error('Unable to decode TagReportData')
-            break
+        #try:
+        ret, data = decode('TagReportData')(data)
+        #except TypeError:  # XXX
+        #    logger.error('Unable to decode TagReportData')
+        #    break
         # print('len(ret) = {}'.format(len(ret)))
         # print('len(data) = {}'.format(len(data)))
         if ret:
@@ -2848,7 +2848,7 @@ def decode_EPCData(data):
     # Decode fields
     (par['EPCLengthBits'], ) = struct.unpack('!H',
                                              body[0:struct.calcsize('!H')])
-    par['EPC'] = body[struct.calcsize('!H'):].encode('hex')
+    par['EPC'] = hexlify(body[struct.calcsize('!H'):])
 
     return par, data[length:]
 
@@ -2876,12 +2876,12 @@ def decode_EPC96(data):
     msgtype = msgtype & BITMASK(7)
     if msgtype != Message_struct['EPC-96']['type']:
         return (None, data)
-    length = tve_header_len + (96 / 8)
+    length = tve_header_len + (96 // 8)
     body = data[tve_header_len:length]
     logger.debug('%s (type=%d len=%d)', func(), msgtype, length)
 
     # Decode fields
-    par['EPC'] = body.encode('hex')
+    par['EPC'] = hexlify(body)
 
     return par, data[length:]
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -27,6 +27,8 @@ import logging
 import struct
 from collections import defaultdict
 from binascii import hexlify
+from six import iteritems
+
 from .util import BIT, BITMASK, func, reverse_dict
 from . import llrp_decoder
 from .llrp_errors import LLRPError
@@ -3367,7 +3369,7 @@ class LLRPMessageDict(dict):
 
 # Reverse dictionary for Message_struct types
 Message_Type2Name = {}
-for msgname, msgstruct in Message_struct.iteritems():
+for msgname, msgstruct in iteritems(Message_struct):
     try:
         ty = msgstruct['type']
     except KeyError:

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2120,7 +2120,7 @@ def encode_ROSpecStartTrigger(par):
     msg_header = '!HHB'
     msg_header_len = struct.calcsize(msg_header)
 
-    data = ''
+    data = b''
     if par['ROSpecStartTriggerType'] == 'Periodic':
         data += encode('PeriodicTriggerValue')(par['PeriodicTriggerValue'])
     elif par['ROSpecStartTriggerType'] == 'GPI':
@@ -2180,7 +2180,7 @@ def encode_ROSpecStopTrigger(par):
     msg_header = '!HHBI'
     msg_header_len = struct.calcsize(msg_header)
 
-    data = ''
+    data = b''
 
     data = struct.pack(msg_header, msgtype,
                        len(data) + msg_header_len,
@@ -2207,7 +2207,7 @@ def encode_AISpec(par):
 
     msg_header = '!HHH'
     msg_header_len = struct.calcsize(msg_header)
-    data = ''
+    data = b''
 
     antid = par['AntennaIDs']
     antennas = []
@@ -2540,7 +2540,7 @@ def encode_ReaderEventNotificationSpec(par):
     msgtype = Message_struct['ReaderEventNotificationSpec']['type']
     states = par['EventNotificationState']
 
-    data = ''
+    data = b''
     for ev_type, flag in states.items():
         parlen = struct.calcsize('!HHHB')
         data += struct.pack('!HHHB', 245, parlen, ev_type,

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -27,9 +27,9 @@ import logging
 import struct
 from collections import defaultdict
 from binascii import hexlify
-from util import BIT, BITMASK, func, reverse_dict
-import llrp_decoder
-from llrp_errors import LLRPError
+from .util import BIT, BITMASK, func, reverse_dict
+from . import llrp_decoder
+from .llrp_errors import LLRPError
 
 #
 # Define exported symbols

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -23,6 +23,7 @@
 # TODO: use generic functions from llrp_decoder where possible
 #
 
+from __future__ import unicode_literals
 import logging
 import struct
 from collections import defaultdict

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -422,7 +422,7 @@ Message_struct['SET_READER_CONFIG_RESPONSE'] = {
 
 # ENABLE_EVENTS_AND_REPORTS
 def encode_EnableEventsAndReports(msg):
-    return ''
+    return b''
 
 
 Message_struct['ENABLE_EVENTS_AND_REPORTS'] = {

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -717,11 +717,11 @@ def decode_ROAccessReport(data):
     # Decode parameters
     msg['TagReportData'] = []
     while True:
-        #try:
-        ret, data = decode('TagReportData')(data)
-        #except TypeError:  # XXX
-        #    logger.error('Unable to decode TagReportData')
-        #    break
+        try:
+            ret, data = decode('TagReportData')(data)
+        except TypeError:  # XXX
+            logger.error('Unable to decode TagReportData')
+            break
         # print('len(ret) = {}'.format(len(ret)))
         # print('len(data) = {}'.format(len(data)))
         if ret:

--- a/sllurp/lock.py
+++ b/sllurp/lock.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
 import logging
 import pprint

--- a/sllurp/log.py
+++ b/sllurp/log.py
@@ -2,6 +2,7 @@
 Logging setup
 """
 
+from __future__ import unicode_literals
 import logging
 
 

--- a/sllurp/test.py
+++ b/sllurp/test.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 import random
 import sllurp

--- a/sllurp/util.py
+++ b/sllurp/util.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from inspect import stack
 import re
 

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -60,7 +60,7 @@ def main(args):
             logger.info('selected recommended Tari of %d for %s', args.tari,
                         args.modulation)
 
-    enabled_antennas = map(lambda x: int(x.strip()), args.antennas.split(','))
+    enabled_antennas = [int(x.strip()) for x in args.antennas.split(',')]
 
     # d.callback will be called when all connections have terminated normally.
     # use d.addCallback(<callable>) to define end-of-program behavior.
@@ -78,7 +78,7 @@ def main(args):
                             mode_identifier=args.mode_identifier,
                             tag_population=args.population,
                             start_inventory=True,
-                            disconnect_when_done=(args.time > 0),
+                            disconnect_when_done=args.time and args.time > 0,
                             reconnect=args.reconnect,
                             tag_content_selector={
                                 'EnableROSpecID': False,


### PR DESCRIPTION
This pull request contains some preliminary Python3 fixes and resolves #66. It includes:

* Unified relative import
* Exclusive use of unicode strings and explicit use of bytes data
* Newer Python APIs and six functions to deal with 2/3 incompatibilities (e.g. Python 3 functions tend to return iterators instead of whole data structures)

Tested "sllurp reset \<ip address\>" and "sllurp inventory \<ip address\>" and they worked without any problems. There might still be some problems with llrp_proto module but it can be fixed in a similar manner in the future.