### PR TITLE
Gracefully handle monotonic import for py2 and py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(filename):
 test_deps = ['pytest']
 install_deps = [
     'click',
-    'monotonic',
+    'monotonic;python_version<"3.3"',
     'twisted',
     'six',
 ]

--- a/sllurp/lock.py
+++ b/sllurp/lock.py
@@ -2,9 +2,9 @@ from __future__ import print_function, unicode_literals
 import argparse
 import logging
 import pprint
-import monotonic
 from twisted.internet import reactor, defer
 
+from sllurp.util import monotonic
 import sllurp.llrp as llrp
 
 startTime = None

--- a/sllurp/util.py
+++ b/sllurp/util.py
@@ -2,6 +2,13 @@ from __future__ import unicode_literals
 from inspect import stack
 import re
 
+try:
+    # monotonic available in time for Python > 3.3
+    from time import monotonic
+except ImportError:
+    # For python2, monotonic package has to be installed.
+    from monotonic import monotonic
+
 
 def BIT(n):
     return 1 << n

--- a/sllurp/verb/access.py
+++ b/sllurp/verb/access.py
@@ -3,9 +3,9 @@ import binascii
 import logging
 import pprint
 import sys
-from monotonic import monotonic
 from twisted.internet import reactor, defer
 
+from sllurp.util import monotonic
 import sllurp.llrp as llrp
 
 startTime = None

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -5,9 +5,9 @@ from __future__ import print_function, division
 import logging
 import pprint
 import time
-from monotonic import monotonic
 from twisted.internet import reactor, defer
 
+from sllurp.util import monotonic
 from sllurp.llrp import LLRPClientFactory
 from sllurp.llrp_proto import Modulation_DefaultTari
 


### PR DESCRIPTION
Only use the monotonic module when needed.