### PR TITLE
Rename impinj specific parameter with Param in the name to fix deserialization bug

### DIFF
--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2474,9 +2474,9 @@ def encode_ROReportSpec(par):
     msg_header_len = struct.calcsize(msg_header)
 
     data = encode('TagReportContentSelector')(par['TagReportContentSelector'])
-    if 'ImpinjTagReportContentSelector' in par:
-        data += encode('ImpinjTagReportContentSelector')(
-            par['ImpinjTagReportContentSelector'])
+    if 'ImpinjTagReportContentSelectorParameter' in par:
+        data += encode('ImpinjTagReportContentSelectorParameter')(
+            par['ImpinjTagReportContentSelectorParameter'])
 
     data = struct.pack(msg_header, msgtype,
                        len(data) + msg_header_len,
@@ -2491,7 +2491,7 @@ Message_struct['ROReportSpec'] = {
         'N',
         'ROReportTrigger',
         'TagReportContentSelector',
-        'ImpinjTagReportContentSelector',
+        'ImpinjTagReportContentSelectorParameter',
     ],
     'encode': encode_ROReportSpec
 }
@@ -3157,8 +3157,8 @@ Message_struct['ParameterError'] = {
 }
 
 
-def encode_ImpinjTagReportContentSelector(par):
-    msgtype = Message_struct['ImpinjTagReportContentSelector']['type']
+def encode_ImpinjTagReportContentSelectorParameter(par):
+    msgtype = Message_struct['ImpinjTagReportContentSelectorParameter']['type']
     msg_header = '!HH'
     msg_header_len = struct.calcsize(msg_header)
 
@@ -3174,7 +3174,7 @@ def encode_ImpinjTagReportContentSelector(par):
     return header + data
 
 
-Message_struct['ImpinjTagReportContentSelector'] = {
+Message_struct['ImpinjTagReportContentSelectorParameter'] = {
     'type': 1023,
     'fields': [
         'VendorID',
@@ -3183,7 +3183,7 @@ Message_struct['ImpinjTagReportContentSelector'] = {
         'EnablePeakRSSI',
         'EnableRFDopplerFrequency'
     ],
-    'encode': encode_ImpinjTagReportContentSelector
+    'encode': encode_ImpinjTagReportContentSelectorParameter
 }
 
 
@@ -3363,7 +3363,7 @@ class LLRPROSpec(dict):
 
         if impinj_tag_content_selector:
             self['ROSpec']['ROReportSpec'][
-                'ImpinjTagReportContentSelector'] = {
+                'ImpinjTagReportContentSelectorParameter'] = {
                 'VendorID': 25882,
                 'Subtype': 50,
                 'EnableRFPhaseAngle': {


### PR DESCRIPTION
Fixes error: "Cannot find decoder for message type 1023"
that happen because Message_Type2Name is just looking
at "type" in message_struct, and that for customer param
and messages, the type value will be the same (1023).

So the "name" that will be returned would be somehow random.
Message_Type2Name ignore entries with "PARAM" in the name, so rename the
custom ImpinjTagReportContentSelector Param with Parameter in the name
so that it will be ignored by Message_Type2Name.

This is a short time fix, and a proper handling of custom message and
parameters should be added.