### PR TITLE
Fixes ascii decode error for llrp_data2xml function.

### DIFF
--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -3263,7 +3263,7 @@ def llrp_data2xml(msg):
                 for e in sub:
                     str += __llrp_data2xml(e, p, level + 1)
             else:
-                str += tabs + '\t<%s>%s</%s>\n' % (p, sub, p)
+                str += tabs + '\t<%s>%r</%s>\n' % (p, sub, p)
 
         str += tabs + '</%s>\n' % name
 


### PR DESCRIPTION
Fixes the following error that can happen for debug output of
GET_READER_CAPABILITIES_RESPONSE for example:

    ans += __llrp_data2xml(msg[p], p)
  File "/home/flo/.virtualenvs/tmp2slurp/lib/python2.7/site-packages/sllurp-0.4.2-py2.7.egg/sllurp/llrp_proto.py", line 3265, in __llrp_data2xml
    str += tabs + '\t<%s>%s</%s>\n' % (p, sub, p)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 8: ordinal not in range(128)
Logged from file llrp.py, line 365

This will output the "repr" of the sub object escaping any non ascii characters.
In my case, I had such a "string" when displaying:
AirProtocolLLRPCapabilities that is not deserialized.