### PR TITLE
Fixes decode_FrequencyInformation that was broken, especially when hopping is false

### DIFF
--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -1034,7 +1034,7 @@ def decode_FrequencyHopTable(data):
     body = body[fmt_len:]
     num = int(par['NumHops'])
     for x in range(1, num + 1):
-        par['Frequency' + str(x)] = struct.unpack(id_fmt, body[: id_fmt_len])
+        (par['Frequency' + str(x)], ) = struct.unpack(id_fmt, body[: id_fmt_len])
         body = body[id_fmt_len:]
 
     return par, data[length:]
@@ -1071,11 +1071,11 @@ def decode_FixedFrequencyTable(data):
     id_fmt = '!I'
     id_fmt_len = struct.calcsize(id_fmt)
     # Decode fields
-    par['NumFrequencies'] = struct.unpack(fmt, body[: fmt_len])
+    (par['NumFrequencies'], ) = struct.unpack(fmt, body[: fmt_len])
     body = body[fmt_len:]
     num = int(par['NumFrequencies'])
     for x in range(1, num + 1):
-        par['Frequency' + str(x)] = struct.unpack(id_fmt, body[:id_fmt_len])
+        (par['Frequency' + str(x)], ) = struct.unpack(id_fmt, body[:id_fmt_len])
         body = body[id_fmt_len:]
 
     return par, data[length:]
@@ -1088,7 +1088,7 @@ Message_struct['FixedFrequencyTable'] = {
         'NumFrequencies',
         'Frequencies'
     ],
-    'decode': decode_FrequencyInformation
+    'decode': decode_FixedFrequencyTable
 }
 
 


### PR DESCRIPTION
There was a typo in the decode function to use for decoding FixedFrequencyTable.

There was also a bug with unpack in FixedFrequencyTable and FrequencyHopTable
as unpack return a tuple even for a single element.

Example of good wrong output for an ETSI device:
u'UHFBandCapabilities': {u'FrequencyInformation': {u'Hopping': False},

Example of good output for the same device:
u'UHFBandCapabilities': {u'FrequencyInformation': {u'FixedFrequencyTable': {u'Frequency1': 865700,
                                                                            u'Frequency2': 866300,
                                                                            u'Frequency3': 866900,
                                                                            u'Frequency4': 867500,
                                                                            u'NumFrequencies': 4},
                                                   u'Hopping': False},