### PR TITLE
Fixed frequency support (for Impinj readers in supported regions)

### DIFF
--- a/run_inventory.sh
+++ b/run_inventory.sh
@@ -4,6 +4,6 @@ python3 -m venv .venv &&
 source .venv/bin/activate &&
 pip3 install wheel &&
 pip3 install . &&
-sllurp inventory -s 0 -P 2 --mode-identifier 0 --impinj-search-mode 2  192.168.0.100
+sllurp inventory -s 0 -P 2 --impinj-fixed-freq --mode-identifier 0 --impinj-search-mode 2  192.168.0.100
 deactivate &&
 rm -rf .venv

--- a/run_inventory.sh
+++ b/run_inventory.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+python3 -m venv .venv &&
+source .venv/bin/activate &&
+pip3 install wheel &&
+pip3 install . &&
+sllurp inventory -s 0 -P 2 --mode-identifier 0 --impinj-search-mode 2  192.168.0.100
+deactivate &&
+rm -rf .venv

--- a/run_inventory.sh
+++ b/run_inventory.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-python3 -m venv .venv &&
-source .venv/bin/activate &&
-pip3 install wheel &&
-pip3 install . &&
-sllurp inventory -s 0 -P 2 --impinj-fixed-freq --mode-identifier 0 --impinj-search-mode 2  192.168.0.100
-deactivate &&
-rm -rf .venv

--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -57,11 +57,14 @@ def cli(debug, logfile):
 @click.option('--impinj-reports', is_flag=True, default=False,
               help='Enable Impinj tag report content '
               '(Phase angle, RSSI, Doppler)')
+@click.option('--impinj-fixed-freq', is_flag=True, default=False,
+              help='Fix operating frequency (dependent '
+              'on operating region if possible)')
 def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
               modulation, tari, session, mode_identifier,
               tag_population, reconnect,
               impinj_extended_configuration,
-              impinj_search_mode, impinj_reports):
+              impinj_search_mode, impinj_reports, impinj_fixed_freq):
     """Conduct inventory (searching the area around the antennas)."""
     # XXX band-aid hack to provide many args to _inventory.main
     Args = namedtuple('Args', ['host', 'port', 'time', 'every_n', 'antennas',
@@ -70,7 +73,8 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
                                'reconnect',
                                'impinj_extended_configuration',
                                'impinj_search_mode',
-                               'impinj_reports'])
+                               'impinj_reports', 
+                               'impinj_fixed_freq'])
     args = Args(host=host, port=port, time=time, every_n=report_every_n_tags,
                 antennas=antennas, tx_power=tx_power, modulation=modulation,
                 tari=tari, session=session, population=tag_population,
@@ -78,7 +82,8 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
                 reconnect=reconnect,
                 impinj_extended_configuration=impinj_extended_configuration,
                 impinj_search_mode=impinj_search_mode,
-                impinj_reports=impinj_reports)
+                impinj_reports=impinj_reports,
+                impinj_fixed_freq=impinj_fixed_freq)
     logger.debug('inventory args: %s', args)
     _inventory.main(args)
 

--- a/sllurp/llrp.py
+++ b/sllurp/llrp.py
@@ -173,7 +173,8 @@ class LLRPClient(LineReceiver):
                  session=2, tag_population=4,
                  impinj_extended_configuration=False,
                  impinj_search_mode=None,
-                 impinj_tag_content_selector=None):
+                 impinj_tag_content_selector=None,
+                 impinj_fixed_frequency_param=None):
         self.factory = factory
         self.setRawMode()
         self.state = LLRPClient.STATE_DISCONNECTED
@@ -208,11 +209,13 @@ class LLRPClient(LineReceiver):
         if self.start_inventory:
             logger.info('will start inventory on connect')
         if (impinj_search_mode is not None or
-                impinj_tag_content_selector is not None):
+                impinj_tag_content_selector is not None or
+                impinj_fixed_frequency_param is not None):
             logger.info('Enabling Impinj extensions')
         self.impinj_extended_configuration = impinj_extended_configuration
         self.impinj_search_mode = impinj_search_mode
         self.impinj_tag_content_selector = impinj_tag_content_selector
+        self.impinj_fixed_frequency_param = impinj_fixed_frequency_param
 
         logger.info('using antennas: %s', self.antennas)
         logger.info('transmit power: %s', self.tx_power)
@@ -468,7 +471,8 @@ class LLRPClient(LineReceiver):
 
             if (self.impinj_search_mode is not None or
                     self.impinj_tag_content_selector is not None or
-                    self.impinj_extended_configuration is not None):
+                    self.impinj_extended_configuration is not None or
+                    self.impinj_fixed_frequency_param is not None):
                 caps = defer.Deferred()
                 caps.addCallback(self.send_GET_READER_CAPABILITIES,
                                  onCompletion=d)
@@ -1089,6 +1093,9 @@ class LLRPClient(LineReceiver):
         if self.impinj_tag_content_selector is not None:
             rospec_kwargs['impinj_tag_content_selector'] = \
                 self.impinj_tag_content_selector
+        if self.impinj_fixed_frequency_param is not None:
+            rospec_kwargs['impinj_fixed_frequency_param'] = \
+                self.impinj_fixed_frequency_param
 
         self.rospec = LLRPROSpec(self.reader_mode, 1, **rospec_kwargs)
         logger.debug('ROSpec: %s', self.rospec)

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -3841,7 +3841,8 @@ class LLRPROSpec(dict):
                  report_every_n_tags=None, report_timeout_ms=0,
                  tag_content_selector={}, tari=None,
                  session=2, tag_population=4,
-                 impinj_search_mode=None, impinj_tag_content_selector=None):
+                 impinj_search_mode=None, impinj_tag_content_selector=None,
+                 impinj_fixed_frequency_param=None):
         # Sanity checks
         if rospecid <= 0:
             raise LLRPError('invalid ROSpec message ID {} (need >0)'.format(
@@ -3967,12 +3968,16 @@ class LLRPROSpec(dict):
                 antconf['C1G2InventoryCommand']\
                     ['ImpinjInventorySearchModeParameter'] = int(impinj_search_mode)
 
-            antconf['C1G2InventoryCommand']\
-                ['ImpinjFixedFrequencyListParameter'] = {
-                    'FixedFrequencyMode': 2,
-                    'ChannelListCount': 1,
-                    'ChannelListIndex': 1
-                }
+            if impinj_fixed_frequency_param is not None:
+                antconf['C1G2InventoryCommand']\
+                    ['ImpinjFixedFrequencyListParameter'] = {
+                        'FixedFrequencyMode': 
+                            impinj_fixed_frequency_param['FixedFrequencyMode'],
+                        'ChannelListCount': 
+                            impinj_fixed_frequency_param['ChannelListCount'],
+                        'ChannelListIndex': 
+                            impinj_fixed_frequency_param['ChannelListIndex']
+                    }
 
             ips['AntennaConfiguration'].append(antconf)
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -3697,10 +3697,11 @@ def encode_ImpinjFixedFrequencyListParameter(par):
         'VendorID': msg_struct_param['vendorid'],
         'Subtype': msg_struct_param['subtype']
     }
+    channellist = par.get('ChannelListIndex')
     payload = struct.pack('!H', par.get('FixedFrequencyMode'))
     payload += struct.pack('!H', 0) # Reserved space
-    payload += struct.pack('!H', par.get('ChannelListCount'))
-    for index in par.get('ChannelListIndex'):
+    payload += struct.pack('!H', len(channellist))
+    for index in channellist:
         payload += struct.pack('!H', index)
     custom_par['Payload'] = payload
 
@@ -3973,8 +3974,6 @@ class LLRPROSpec(dict):
                     ['ImpinjFixedFrequencyListParameter'] = {
                         'FixedFrequencyMode': 
                             impinj_fixed_frequency_param['FixedFrequencyMode'],
-                        'ChannelListCount': 
-                            impinj_fixed_frequency_param['ChannelListCount'],
                         'ChannelListIndex': 
                             impinj_fixed_frequency_param['ChannelListIndex']
                     }

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2480,6 +2480,9 @@ def encode_C1G2InventoryCommand(par):
     if 'ImpinjInventorySearchModeParameter' in par:
         data += encode('ImpinjInventorySearchModeParameter')(
             par['ImpinjInventorySearchModeParameter'])
+    if 'ImpinjFixedFrequencyListParameter' in par:
+        data += encode('ImpinjFixedFrequencyListParameter')(
+            par['ImpinjFixedFrequencyListParameter'])
 
     data = struct.pack(msg_header, msgtype,
                        len(data) + struct.calcsize(msg_header)) + data
@@ -2494,7 +2497,8 @@ Message_struct['C1G2InventoryCommand'] = {
         'C1G2RFControl',
         'C1G2SingulationControl',
         # XXX custom parameters
-        'ImpinjInventorySearchModeParameter'
+        'ImpinjInventorySearchModeParameter',
+        'ImpinjFixedFrequencyListParameter'
     ],
     'encode': encode_C1G2InventoryCommand
 }
@@ -3687,6 +3691,32 @@ Message_struct['ImpinjInventorySearchModeParameter'] = {
     'encode': encode_ImpinjInventorySearchModeParameter
 }
 
+def encode_ImpinjFixedFrequencyListParameter(par):
+    msg_struct_param = Message_struct['ImpinjFixedFrequencyListParameter']
+    custom_par = {
+        'VendorID': msg_struct_param['vendorid'],
+        'Subtype': msg_struct_param['subtype']
+    }
+    payload = struct.pack('!H', par.get('FixedFrequencyMode'))
+    payload += struct.pack('!H', 0) # Reserved space
+    payload += struct.pack('!H', par.get('ChannelListCount'))
+    for index in par.get('ChannelListIndex'):
+        payload += struct.pack('!H', index)
+    custom_par['Payload'] = payload
+
+    return encode('CustomParameter')(custom_par)
+
+Message_struct['ImpinjFixedFrequencyListParameter'] = {
+    'vendorid': 25882,
+    'subtype': 26,
+    'fields': [
+        'FixedFrequencyMode',
+        'Reserved',
+        'ChannelListCount',
+        'ChannelListIndex'
+    ],
+    'encode': encode_ImpinjFixedFrequencyListParameter
+}
 
 def encode_ImpinjTagReportContentSelectorParameter(par):
     msg_struct_param = Message_struct['ImpinjTagReportContentSelectorParameter']
@@ -3936,6 +3966,13 @@ class LLRPROSpec(dict):
                 logger.info('impinj_search_mode: %s', impinj_search_mode)
                 antconf['C1G2InventoryCommand']\
                     ['ImpinjInventorySearchModeParameter'] = int(impinj_search_mode)
+
+            antconf['C1G2InventoryCommand']\
+                ['ImpinjFixedFrequencyListParameter'] = {
+                    'FixedFrequencyMode': 2,
+                    'ChannelListCount': 1,
+                    'ChannelListIndex': 1
+                }
 
             ips['AntennaConfiguration'].append(antconf)
 

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -113,7 +113,6 @@ def main(args):
     if args.impinj_fixed_freq:
         factory_args['impinj_fixed_frequency_param'] = {
             'FixedFrequencyMode': 2,
-            'ChannelListCount': 1,
             'ChannelListIndex': [1]
         }
 

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -110,11 +110,12 @@ def main(args):
             'EnablePeakRSSI': False,
             'EnableRFDopplerFrequency': False
         }
-    factory_args['impinj_fixed_frequency_param'] = {
-        'FixedFrequencyMode': 0,
-        'ChannelListCount': 1,
-        'ChannelListIndex': [1]
-    }
+    if args.impinj_fixed_freq:
+        factory_args['impinj_fixed_frequency_param'] = {
+            'FixedFrequencyMode': 2,
+            'ChannelListCount': 1,
+            'ChannelListIndex': [1]
+        }
 
     fac = LLRPClientFactory(**factory_args)
 

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -110,6 +110,11 @@ def main(args):
             'EnablePeakRSSI': False,
             'EnableRFDopplerFrequency': False
         }
+    factory_args['impinj_fixed_frequency_param'] = {
+        'FixedFrequencyMode': 0,
+        'ChannelListCount': 1,
+        'ChannelListIndex': [1]
+    }
 
     fac = LLRPClientFactory(**factory_args)
 


### PR DESCRIPTION
I was looking into making my reader use a single frequency to counteract the phase angle shift offsets caused by the frequency hopping. However after initial implementation I found that FCC regulations (which my reader unfortunately is) don't allow fixed frequencies. As I couldn't change my readers region (although I'm in europe, reader's a hand me down from a US university) I thought maybe some other people could use the fixed frequency settings.

As I'm not able to test if the fixed frequency really works (I only get an error that I'm not in the correct region), maybe @fviard can try it on his ETSI reader.

I implemented the ImpinjFixedFrequencyList parameter from the Octane LLRP document from Impinj (page 119).