### PR TITLE
Added tag filtering based on (part of) EPC ID

### DIFF
--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -49,6 +49,8 @@ def cli(debug, logfile):
               help="Tag Population value (default 4)")
 @click.option('-r', '--reconnect', is_flag=True, default=False,
               help='reconnect on connection failure or loss')
+@click.option('-tag-filter', type=str, default='', help='Filter inventory '
+                    'on EPC ID (or part of ID)')
 @click.option('--impinj-extended-configuration', is_flag=True, default=False,
               help=('Get Impinj extended configuration values'))
 @click.option('--impinj-search-mode', type=click.Choice(['1', '2']),
@@ -59,7 +61,7 @@ def cli(debug, logfile):
               '(Phase angle, RSSI, Doppler)')
 def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
               modulation, tari, session, mode_identifier,
-              tag_population, reconnect,
+              tag_population, reconnect, tag_filter_mask,
               impinj_extended_configuration,
               impinj_search_mode, impinj_reports):
     """Conduct inventory (searching the area around the antennas)."""
@@ -67,7 +69,7 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
     Args = namedtuple('Args', ['host', 'port', 'time', 'every_n', 'antennas',
                                'tx_power', 'modulation', 'tari', 'session',
                                'population', 'mode_identifier',
-                               'reconnect',
+                               'reconnect', 'tag_filter_mask',
                                'impinj_extended_configuration',
                                'impinj_search_mode',
                                'impinj_reports'])
@@ -75,7 +77,7 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
                 antennas=antennas, tx_power=tx_power, modulation=modulation,
                 tari=tari, session=session, population=tag_population,
                 mode_identifier=mode_identifier,
-                reconnect=reconnect,
+                reconnect=reconnect, tag_filter_mask=tag_filter_mask,
                 impinj_extended_configuration=impinj_extended_configuration,
                 impinj_search_mode=impinj_search_mode,
                 impinj_reports=impinj_reports)

--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -49,8 +49,8 @@ def cli(debug, logfile):
               help="Tag Population value (default 4)")
 @click.option('-r', '--reconnect', is_flag=True, default=False,
               help='reconnect on connection failure or loss')
-@click.option('-tag-filter', type=str, default='', help='Filter inventory '
-                    'on EPC ID (or part of ID)')
+@click.option('--tag-filter-mask', type=str, default=None, 
+              help=('Filter inventory on EPC ID (or part of ID)'))
 @click.option('--impinj-extended-configuration', is_flag=True, default=False,
               help=('Get Impinj extended configuration values'))
 @click.option('--impinj-search-mode', type=click.Choice(['1', '2']),

--- a/sllurp/llrp.py
+++ b/sllurp/llrp.py
@@ -171,6 +171,7 @@ class LLRPClient(LineReceiver):
                  tag_content_selector={},
                  mode_identifier=None,
                  session=2, tag_population=4,
+                 tag_filter_mask=None,
                  impinj_extended_configuration=False,
                  impinj_search_mode=None,
                  impinj_tag_content_selector=None):
@@ -195,6 +196,7 @@ class LLRPClient(LineReceiver):
         self.session = session
         self.tag_population = tag_population
         self.mode_identifier = mode_identifier
+        self.tag_filter_mask = tag_filter_mask
         self.antennas = antennas
         self.duration = duration
         self.peername = None
@@ -1083,6 +1085,8 @@ class LLRPClient(LineReceiver):
             tari=self.tari,
             tag_population=self.tag_population
         )
+        if self.tag_filter_mask is not None:
+            rospec_kwargs['tag_filter_mask'] = self.tag_filter_mask
         logger.info('Impinj search mode? %s', self.impinj_search_mode)
         if self.impinj_search_mode is not None:
             rospec_kwargs['impinj_search_mode'] = self.impinj_search_mode

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2504,8 +2504,7 @@ Message_struct['C1G2InventoryCommand'] = {
 def encode_C1G2Filter(par):
     msgtype = Message_struct['C1G2Filter']['type']
     msg_header = '!HH'
-    data = struct.pack('!B', par['T'] << 6)
-    # data = struct.pack('!B', 0)
+    data = struct.pack('!B', Message_struct['C1G2Filter']['T'] << 6) # XXX: hardcoded trucation for now
     if 'C1G2TagInventoryMask' in par:
         data += encode('C1G2TagInventoryMask')(
             par['C1G2TagInventoryMask'])
@@ -3960,10 +3959,12 @@ class LLRPROSpec(dict):
                 }
             }
             if tag_filter_mask:
-                antconf['C1G2InventoryCommand']['C1G2Filter']['C1G2TagInventoryMask'] = {
-                    'MB': 1,    # EPC bank
-                    'Pointer': 0x20,    # Third word starts the EPC ID
-                    'TagMask': tag_filter_mask
+                antconf['C1G2InventoryCommand']['C1G2Filter'] = {
+                    'C1G2TagInventoryMask': {
+                        'MB': 1,    # EPC bank
+                        'Pointer': 0x20,    # Third word starts the EPC ID
+                        'TagMask': tag_filter_mask
+                    }
                 }
             if reader_mode:
                 rfcont = {

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -3845,7 +3845,7 @@ class LLRPROSpec(dict):
                  antennas=(1,), tx_power=0, duration_sec=None,
                  report_every_n_tags=None, report_timeout_ms=0,
                  tag_content_selector={}, tari=None,
-                 session=2, tag_population=4,
+                 session=2, tag_population=4, tag_filter_mask=None,
                  impinj_search_mode=None, impinj_tag_content_selector=None):
         # Sanity checks
         if rospecid <= 0:
@@ -3959,6 +3959,12 @@ class LLRPROSpec(dict):
                     },
                 }
             }
+            if tag_filter_mask:
+                antconf['C1G2InventoryCommand']['C1G2Filter']['C1G2TagInventoryMask'] = {
+                    'MB': 1,    # EPC bank
+                    'Pointer': 0x20,    # Third word starts the EPC ID
+                    'TagMask': tag_filter_mask
+                }
             if reader_mode:
                 rfcont = {
                     'ModeIndex': mode_index,

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2502,13 +2502,25 @@ Message_struct['C1G2InventoryCommand'] = {
 
 # 16.3.1.2.1.1 C1G2Filter Parameter
 def encode_C1G2Filter(par):
-    raise NotImplementedError
+    msgtype = Message_struct['C1G2Filter']['type']
+    msg_header = '!HH'
+    data = struct.pack('!B', par['T'] << 6)
+    # data = struct.pack('!B', 0)
+    if 'C1G2TagInventoryMask' in par:
+        data += encode('C1G2TagInventoryMask')(
+            par['C1G2TagInventoryMask'])
+    data = struct.pack(msg_header, msgtype,
+                       len(data) + struct.calcsize(msg_header)) + data
+    return data
 
 
 Message_struct['C1G2Filter'] = {
     'type': 331,
-    'fields': [],
-    'encode': lambda: None
+    'T': 0,
+    'fields': [
+        'C1G2TagInventoryMask'
+    ],
+    'encode': encode_C1G2Filter
 }
 
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2527,6 +2527,8 @@ def encode_C1G2TagInventoryMask(par):
     msgtype = Message_struct['C1G2TagInventoryMask']['type']
     msg_header = '!HH'
     maskbitcount = len(par['TagMask'])*4
+    if len(par['TagMask']) % 2 != 0:    # check for odd numbered length hexstring
+        par['TagMask'] += '0'           # pad with zero
     data = struct.pack('!B', par['MB'] << 6)
     data += struct.pack('!H', par['Pointer'])
     if maskbitcount:

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 import logging
 import struct
 from collections import defaultdict
-from binascii import hexlify
+from binascii import hexlify, unhexlify
 
 from .util import BIT, BITMASK, func, reverse_dict, iteritems
 from . import llrp_decoder
@@ -2523,6 +2523,29 @@ Message_struct['C1G2Filter'] = {
     'encode': encode_C1G2Filter
 }
 
+# 16.3.1.2.1.1.1 C1G2TagInventoryMask Parameter
+def encode_C1G2TagInventoryMask(par):
+    msgtype = Message_struct['C1G2TagInventoryMask']['type']
+    msg_header = '!HH'
+    maskbitcount = len(par['TagMask'])*4
+    data = struct.pack('!B', par['MB'] << 6)
+    data += struct.pack('!H', par['Pointer'])
+    if maskbitcount:
+        data += struct.pack('!H', maskbitcount)
+        data += unhexlify(par['TagMask'])
+    data = struct.pack(msg_header, msgtype,
+                       len(data) + struct.calcsize(msg_header)) + data
+    return data
+
+Message_struct['C1G2TagInventoryMask'] = {
+    'type': 332,
+    'fields': [
+        'MB',
+        'Pointer',
+        'TagMask'
+    ],
+    'encode': encode_C1G2TagInventoryMask
+}
 
 # 16.3.1.2.1.2 C1G2RFControl Parameter
 def encode_C1G2RFControl(par):

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -88,6 +88,7 @@ def main(args):
         start_inventory=True,
         disconnect_when_done=args.time and args.time > 0,
         reconnect=args.reconnect,
+        tag_filter_mask=args.tag_filter_mask,
         tag_content_selector={
             'EnableROSpecID': False,
             'EnableSpecIndex': False,


### PR DESCRIPTION
Implemented part of the C1G2Filter parameter and subsequently implemented the C1G2TagInventoryMask parameter so the reader can apply an EPC mask and only select tags will respond. 

To use this the option `--tag-filter-mask <epc-id>` can be added to the inventory command. The epc-id can be a full 96-bit (or larger) epc-id or part of an epc-id. 
For example: 
`sllurp inventory --tag-filter-mask 123`
causes only tags starting with 123 in their epc-id to respond. 

This can be extended with an option that allows filtering on TID etc. but I haven't specifically looked into that for now as I only work with EPC.