### PR TITLE
Multiple --tag-filter-mask params

### DIFF
--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -47,8 +47,9 @@ def cli(debug, logfile):
               help="Tag Population value (default 4)")
 @click.option('-r', '--reconnect', is_flag=True, default=False,
               help='reconnect on connection failure or loss')
-@click.option('--tag-filter-mask', type=str, default=None, 
-              help=('Filter inventory on EPC ID (or part of ID)'))
+@click.option('--tag-filter-mask', type=str, default=[], multiple=True,
+              help=('Filter inventory on EPC (or prefix of EPC); multiple'
+                    ' args allowed'))
 @click.option('--impinj-extended-configuration', is_flag=True, default=False,
               help=('Get Impinj extended configuration values'))
 @click.option('--impinj-search-mode', type=click.Choice(['1', '2']),
@@ -73,7 +74,7 @@ def inventory(host, port, time, report_every_n_tags, antennas, tx_power,
                                'reconnect', 'tag_filter_mask',
                                'impinj_extended_configuration',
                                'impinj_search_mode',
-                               'impinj_reports', 
+                               'impinj_reports',
                                'impinj_fixed_freq'])
     args = Args(host=host, port=port, time=time, every_n=report_every_n_tags,
                 antennas=antennas, tx_power=tx_power,

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -4000,7 +4000,7 @@ class LLRPROSpec(dict):
                     'C1G2TagInventoryMask': {
                         'MB': 1,    # EPC bank
                         'Pointer': 0x20,    # Third word starts the EPC ID
-                        'TagMask': tag_filter_mask
+                        'TagMask': tfm
                     }
                 })
             if tag_filters:

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2466,7 +2466,12 @@ def encode_C1G2InventoryCommand(par):
     msg_header = '!HH'
     data = struct.pack('!B', (par['TagInventoryStateAware'] and 1 or 0) << 7)
     if 'C1G2Filter' in par:
-        data += encode('C1G2Filter')(par['C1G2Filter'])
+        filters = par['C1G2Filter']
+        if isinstance(filters, list):
+            for filt in filters:
+                data += encode('C1G2Filter')(filt)
+        else: # only one filter
+            data += encode('C1G2Filter')(filters)
     if 'C1G2RFControl' in par:
         data += encode('C1G2RFControl')(par['C1G2RFControl'])
     if 'C1G2SingulationControl' in par:
@@ -3871,7 +3876,7 @@ class LLRPROSpec(dict):
                  antennas=(1,), tx_power=0, duration_sec=None,
                  report_every_n_tags=None, report_timeout_ms=0,
                  tag_content_selector={}, tari=None,
-                 session=2, tag_population=4, tag_filter_mask=None,
+                 session=2, tag_population=4, tag_filter_mask=[],
                  impinj_search_mode=None, impinj_tag_content_selector=None,
                  impinj_fixed_frequency_param=None):
         # Sanity checks
@@ -3966,10 +3971,11 @@ class LLRPROSpec(dict):
                     impinj_tag_content_selector['EnableRFDopplerFrequency']
             }
 
+        ips = self['ROSpec']['AISpec']['InventoryParameterSpec']
+
         # patch up per-antenna config
         for antid in antennas:
             transmit_power = tx_power[antid]
-            ips = self['ROSpec']['AISpec']['InventoryParameterSpec']
             antconf = {
                 'AntennaID': antid,
                 'RFTransmitter': {
@@ -3986,14 +3992,20 @@ class LLRPROSpec(dict):
                     },
                 }
             }
-            if tag_filter_mask:
-                antconf['C1G2InventoryCommand']['C1G2Filter'] = {
+
+            # apply one or more tag filters
+            tag_filters = []
+            for tfm in tag_filter_mask:
+                tag_filters.append({
                     'C1G2TagInventoryMask': {
                         'MB': 1,    # EPC bank
                         'Pointer': 0x20,    # Third word starts the EPC ID
                         'TagMask': tag_filter_mask
                     }
-                }
+                })
+            if tag_filters:
+                antconf['C1G2InventoryCommand']['C1G2Filter'] = tag_filters
+
             if reader_mode:
                 rfcont = {
                     'ModeIndex': mode_index,

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -78,6 +78,16 @@ class TestROSpec(unittest.TestCase):
         rospec_str = repr(rospec)
         self.assertNotEqual(rospec_str, '')
 
+    def test_multi_tag_mask(self):
+        fx = FauxClient()
+        rospec = sllurp.llrp.LLRPROSpec(
+            fx.reader_mode, 1,
+            tag_filter_mask=['0123', '4567'])
+        rospec_str = repr(rospec)
+        print(rospec_str)
+        self.assertIn("<TagMask>'0123'</TagMask>", rospec_str)
+        self.assertIn("<TagMask>'4567'</TagMask>", rospec_str)
+
 
 class TestReaderEventNotification(unittest.TestCase):
     def test_decode(self):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -80,13 +80,17 @@ class TestROSpec(unittest.TestCase):
 
     def test_multi_tag_mask(self):
         fx = FauxClient()
+        masks = ['0123', '4567']
         rospec = sllurp.llrp.LLRPROSpec(
             fx.reader_mode, 1,
-            tag_filter_mask=['0123', '4567'])
+            tag_filter_mask=masks)
         rospec_str = repr(rospec)
-        print(rospec_str)
-        self.assertIn("<TagMask>'0123'</TagMask>", rospec_str)
-        self.assertIn("<TagMask>'4567'</TagMask>", rospec_str)
+        filters = rospec['ROSpec']['AISpec']['InventoryParameterSpec'][
+            'AntennaConfiguration'][0]['C1G2InventoryCommand']['C1G2Filter']
+        self.assertEqual(len(filters), 2)
+        self.assertEqual(
+            [f['C1G2TagInventoryMask']['TagMask'] for f in filters],
+            masks)
 
 
 class TestReaderEventNotification(unittest.TestCase):


### PR DESCRIPTION
... probably by turning each into a `C1G2Inventory > C1G2Filter` parameter.

Fixes #121