### PR TITLE
Add encodes for inventory state aware

### DIFF
--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -3978,7 +3978,7 @@ class LLRPROSpec(dict):
 
         state_aware_filter_action = {
             "Target": session + 1,  ## Do not use SL (0), use session
-            "Action": 4,  ## Match => flag = A, unmatch => flag = B
+            "Action": 4,  ## Match => flag = B, unmatch => flag = A
         }
 
         if filter_action:

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -2507,10 +2507,14 @@ Message_struct['C1G2InventoryCommand'] = {
 def encode_C1G2Filter(par):
     msgtype = Message_struct['C1G2Filter']['type']
     msg_header = '!HH'
-    data = struct.pack('!B', Message_struct['C1G2Filter']['T'] << 6) # XXX: hardcoded trucation for now
+    data = struct.pack('!B', Message_struct['C1G2Filter']['T'] << 6) # XXX: hardcoded truncation for now
     if 'C1G2TagInventoryMask' in par:
         data += encode('C1G2TagInventoryMask')(
             par['C1G2TagInventoryMask'])
+    if "C1G2TagInventoryStateAwareFilterAction" in par:
+        data += encode("C1G2TagInventoryStateAwareFilterAction")(
+            par["C1G2TagInventoryStateAwareFilterAction"]
+        )
     data = struct.pack(msg_header, msgtype,
                        len(data) + struct.calcsize(msg_header)) + data
     return data
@@ -2520,7 +2524,8 @@ Message_struct['C1G2Filter'] = {
     'type': 331,
     'T': 0,
     'fields': [
-        'C1G2TagInventoryMask'
+        'C1G2TagInventoryMask',
+	'C1G2TagInventoryStateAwareFilterAction'
     ],
     'encode': encode_C1G2Filter
 }
@@ -2551,6 +2556,23 @@ Message_struct['C1G2TagInventoryMask'] = {
     'encode': encode_C1G2TagInventoryMask
 }
 
+# 16.2.1.2.1.1.2 C1G2TagInventoryStateAwareFilterAction Parameter
+def encode_C1G2TagInventoryStateAwareFilterAction(par):
+    msgtype = Message_struct["C1G2TagInventoryStateAwareFilterAction"]["type"]
+    msg_header = "!HH"
+    data = struct.pack("!B", par["Target"])
+    data += struct.pack("!B", par["Action"])
+    data = struct.pack(msg_header, msgtype, len(data) + struct.calcsize(msg_header)) + data
+    print("******** TagInventoryStateAware")
+    return data
+
+
+Message_struct["C1G2TagInventoryStateAwareFilterAction"] = {
+    "type": 333,
+    "fields": ["Target", "Action"],
+    "encode": encode_C1G2TagInventoryStateAwareFilterAction,
+}
+
 # 16.3.1.2.1.2 C1G2RFControl Parameter
 def encode_C1G2RFControl(par):
     msgtype = Message_struct['C1G2RFControl']['type']
@@ -2579,8 +2601,9 @@ def encode_C1G2SingulationControl(par):
     data = struct.pack('!B', par['Session'] << 6)
     data += struct.pack('!H', par['TagPopulation'])
     data += struct.pack('!I', par['TagTransitTime'])
-    data = struct.pack(msg_header, msgtype,
-                       len(data) + struct.calcsize(msg_header)) + data
+    if "C1G2TagInventoryStateAwareSingulationAction" in par:
+        data += encode("C1G2TagInventoryStateAwareSingulationAction")(par["C1G2TagInventoryStateAwareSingulationAction"])
+    data = struct.pack(msg_header, msgtype, len(data) + struct.calcsize(msg_header)) + data
     return data
 
 
@@ -2590,8 +2613,25 @@ Message_struct['C1G2SingulationControl'] = {
         'Session',
         'TagPopulation',
         'TagTransitTime',
+        'C1G2TagInventoryStateAwareSingulationAction',
     ],
     'encode': encode_C1G2SingulationControl
+}
+
+
+# 16.2.1.2.1.3.1. C1G2TagInventoryStateAwareSingulationAction Parameter
+def encode_C1G2TagInventoryStateAwareSingulationAction(par):
+    msgtype = Message_struct["C1G2TagInventoryStateAwareSingulationAction"]["type"]
+    msg_header = "!HH"
+    data = struct.pack("!B", (par["I"] << 7) | (par["S"] << 6) | (par["A"] << 5))
+    data = struct.pack(msg_header, msgtype, len(data) + struct.calcsize(msg_header)) + data
+    return data
+
+
+Message_struct["C1G2TagInventoryStateAwareSingulationAction"] = {
+    "type": 337,
+    "fields": ["I", "S", "A"],
+    "encode": encode_C1G2TagInventoryStateAwareSingulationAction,
 }
 
 


### PR DESCRIPTION
Hello,

I have written following encodes:
- encode_C1G2TagInventoryStateAwareFilterAction (16.2.1.2.1.1.2 in llrp_1_1-standard-20101013.pdf)
- encode_C1G2TagInventoryStateAwareSingulationAction (16.2.1.2.1.3.1 in llrp_1_1-standard-20101013.pdf)

I tested them by hardcoding parameters in LLRPROSpec class (not added yet in this pull request) and with this following reader:
- [Impinj speedway revolution](https://www.impinj.com/platform/connectivity/speedway-r220)  -> ignored because CanDoTagInventoryStateAwareSingulation = False
- [Zebra FX9600](https://www.zebra.com/us/en/support-downloads/rfid/rfid-readers/fx9600.html) -> works

Tests are not ready. Don't merge yet.

Regards,
