### PR TITLE
Run py2 and py3 tests in separate workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,15 @@
 version: 2
 jobs:
-  build:
+  python2:
     working_directory: ~/sllurp
     docker:
-      - image: circleci/python:3.7
       - image: circleci/python:2.7
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "setup.py" }}
-            - v1-dependencies-
+            - v1-py2-dependencies-{{ checksum "setup.py" }}
+            - v1-py2-dependencies-
       - run:
           name: install python2 dependencies
           command: |
@@ -19,6 +18,25 @@ jobs:
             python2.7 -m virtualenv .venv2
             . .venv2/bin/activate
             pip install -e .[test]
+      - save_cache:
+          paths:
+            - ".venv2"
+          key: v1-py2-dependencies-{{ checksum "setup.py" }}
+      - run:
+          name: run python2 tests
+          command: |
+            . .venv2/bin/activate
+            python2.7 setup.py test
+  python3:
+    working_directory: ~/sllurp
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-py3-dependencies-{{ checksum "setup.py" }}
+            - v1-py3-dependencies-
       - run:
           name: install python3 dependencies
           command: |
@@ -27,16 +45,16 @@ jobs:
             pip3 install -e .[test]
       - save_cache:
           paths:
-            - ".venv2"
             - ".venv3"
-          key: v1-dependencies-{{ checksum "setup.py" }}
-      - run:
-          name: run python2 tests
-          command: |
-            . .venv2/bin/activate
-            python2.7 setup.py test
+          key: v1-py3-dependencies-{{ checksum "setup.py" }}
       - run:
           name: run python3 tests
           command: |
             . .venv3/bin/activate
             python3 setup.py test
+workflows:
+  version: 2
+  py2_and_py3:
+    jobs:
+      - python2
+      - python3


### PR DESCRIPTION
I took advantage of the "workflows" that CircleCI provides, and put the py2 and py3 environment build and tests in separate workflows.  This way they may run in parallel!

it is of course possible to also separate the "environment setup" (i.e., creating the `.venv`) and "test running" into separate workflows, make the latter dependent on the former, and use workspaces to persist the environment (as explained in [the CircleCI Getting Started tutorial](https://circleci.com/docs/2.0/getting-started/#adding-some-changes-to-use-the-workspaces-functionality)) but that has less value as of now.  If we add more tests that could run independent of each other this might be useful, though!