### PR TITLE
Add basic encode support for ReaderEventNotification

### DIFF
--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -835,13 +835,33 @@ def decode_ReaderEventNotification(data):
     return msg
 
 
+def encode_ReaderEventNotification(msg):
+    logger.debug(func())
+    msg_header = '!BII'
+    msg_header_len = struct.calcsize(msg_header)
+    conntype = Message_struct['READER_EVENT_NOTIFICATION']['type']
+    ID = msg['ID']
+    # resolve the ReaderEventNotification Data
+    req = msg['ReaderEventNotificationData']
+    data = encode('ReaderEventNotificationData')(req)
+    logger.debug('ReaderEventNotificationData in ReaderEventNotification: %s', hexlify(data))
+    # add the ReaderEventNotification header
+    #msg_data = struct.pack(msg_header, conntype,
+    #                   len(data) + msg_header_len, ID)
+
+    #logger.debug('ReaderEventNotificationHeader in ReaderEventNotification: %s', hexlify(msg_data))
+    #data = msg_data + data
+    logger.debug('ReaderEventNotification data: %s', hexlify(data))
+    return data
+
 Message_struct['READER_EVENT_NOTIFICATION'] = {
     'type': 63,
     'fields': [
         'Ver', 'Type', 'ID',
         'ReaderEventNotificationData'
     ],
-    'decode': decode_ReaderEventNotification
+    'decode': decode_ReaderEventNotification,
+    'encode': encode_ReaderEventNotification
 }
 
 
@@ -913,9 +933,9 @@ def decode_UTCTimestamp(data):
 
 def encode_UTCTimestamp(par):
     msgtype = Message_struct['UTCTimestamp']['type']
-    msg = '!HHQ'
+    msg_header = '!HHQ'
     msg_len = struct.calcsize(msg_header)
-    data = struct.pack(msg, msgtype, msg_len, par['Microseconds'])
+    data = struct.pack(msg_header, msgtype, msg_len, par['Microseconds'])
     return data
 
 
@@ -3350,6 +3370,17 @@ def decode_ConnectionAttemptEvent(data):
 
     return par, data[length:]
 
+def encode_ConnectionAttemptEvent(msg):
+    logger.debug(func())
+    msgtype = Message_struct['ConnectionAttemptEvent']['type']
+    msg_header = '!HHH'
+    msg_len = struct.calcsize(msg_header)
+    status = ConnEvent_Name2Type[msg['Status']]
+    data = struct.pack(msg_header, msgtype, msg_len, status)
+    logger.debug('ConnectionAttemptEvent data: %s', hexlify(data))
+    return data
+
+
 
 Message_struct['ConnectionAttemptEvent'] = {
     'type': 256,
@@ -3357,7 +3388,8 @@ Message_struct['ConnectionAttemptEvent'] = {
         'Type',
         'Status'
     ],
-    'decode': decode_ConnectionAttemptEvent
+    'decode': decode_ConnectionAttemptEvent,
+    'encode': encode_ConnectionAttemptEvent
 }
 
 
@@ -3467,6 +3499,20 @@ def decode_ReaderEventNotificationData(data):
     return par, body
 
 
+def encode_ReaderEventNotificationData(msg):
+    # XXX Does not implement most fields.
+    logger.debug(func())
+    msg_header = '!HH'
+    msg_header_len = struct.calcsize(msg_header)
+    eventtype = Message_struct['ReaderEventNotificationData']['type']
+    # add the timestamp
+    data = encode('UTCTimestamp')(msg['UTCTimestamp'])
+    data += encode('ConnectionAttemptEvent')(msg['ConnectionAttemptEvent'])
+    data = struct.pack(msg_header, eventtype,
+                       len(data) + msg_header_len) + data
+    logger.debug('ReaderEventNotificationData: %s', hexlify(data))
+    return data
+
 Message_struct['ReaderEventNotificationData'] = {
     'type': 246,
     'fields': [
@@ -3484,7 +3530,8 @@ Message_struct['ReaderEventNotificationData'] = {
         'ConnectionCloseEvent',
         'SpecLoopEvent'
     ],
-    'decode': decode_ReaderEventNotificationData
+    'decode': decode_ReaderEventNotificationData,
+    'encode': encode_ReaderEventNotificationData
 }
 
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -837,20 +837,9 @@ def decode_ReaderEventNotification(data):
 
 def encode_ReaderEventNotification(msg):
     logger.debug(func())
-    msg_header = '!BII'
-    msg_header_len = struct.calcsize(msg_header)
-    conntype = Message_struct['READER_EVENT_NOTIFICATION']['type']
-    ID = msg['ID']
     # resolve the ReaderEventNotification Data
     req = msg['ReaderEventNotificationData']
     data = encode('ReaderEventNotificationData')(req)
-    logger.debug('ReaderEventNotificationData in ReaderEventNotification: %s', hexlify(data))
-    # add the ReaderEventNotification header
-    #msg_data = struct.pack(msg_header, conntype,
-    #                   len(data) + msg_header_len, ID)
-
-    #logger.debug('ReaderEventNotificationHeader in ReaderEventNotification: %s', hexlify(msg_data))
-    #data = msg_data + data
     logger.debug('ReaderEventNotification data: %s', hexlify(data))
     return data
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -101,6 +101,28 @@ class TestReaderEventNotification(unittest.TestCase):
         client.transport = MockConn('')
         client.dataReceived(data)
 
+    def test_encode(self):
+        expected_result = binascii.unhexlify('043f000000200000000000f600160080'
+                                             '000c0000000000000000010000060000')
+        msg_dict = {'READER_EVENT_NOTIFICATION': {
+                        'Ver': 1,
+                        'Type': 63,
+                        'ID': 0,
+                        'ReaderEventNotificationData':
+                        {
+                            'UTCTimestamp':
+                            {
+                                'Microseconds': 0
+                            },
+                            'ConnectionAttemptEvent' :
+                            {
+                                'Status': 'Success'
+                            }
+                        }
+                    }}
+        llrp_msg = sllurp.llrp.LLRPMessage(msgdict=msg_dict)
+        self.assertEqual(expected_result, llrp_msg.msgbytes)
+
 
 class TestDecodeROAccessReport (unittest.TestCase):
     _r = """


### PR DESCRIPTION
Hi,
Thanks for the code. Feedback welcome - I'm new to the library and actually using its protocol definitions and immensely helpful functionality to build a hacky server that converts a proprietary wire protocol (HRP) into LLRP.

This patch adds basic encode support for ReaderEventNotification messages including
the most basic ReaderEventNotificationData, ConnectionAttemptEvent.

There are new methods in llrp_proto:
* encode_ReaderEventNotification
* encode_ConnectionAttemptEvent

and new test for ReaderEventNotification that will test the full chain.

I also fixed a bug with encoding UTCTimeStamps (wrong message header was used).

There is a question to ask - are you OK with this encode functionality living in sllurp/llrp_proto? Since it's not likely an LLRP client would ever need to encode a ReaderEventNotification. If you're OK with that, I should have some more similar patches for you over coming weeks.