### PR TITLE
Protocol enhancements for Config and Capabilities 

### DIFF
--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -3401,6 +3401,24 @@ Message_struct['ROSpecID'] = {
     'tv_encoded': True,
 }
 
+# 16.2.7.3.11 LastSeenTimestampUTC Parameter
+def encode_LastSeenTimestampUTC(msg):
+    # TODO this is a general solution for all TV encoded timestamps
+    data = struct.pack('!BQ', msg['Type'] | BIT(7), msg['Microseconds'])
+    return data
+
+
+Message_struct['LastSeenTimestampUTC'] = {
+    'type': 4,
+    'fields': [
+        'Type',
+        'Microseconds'
+    ],
+    'encode': encode_LastSeenTimestampUTC,
+    'tv_encoded': True,
+}
+
+
 # 16.2.7.6.1 HoppingEvent Parameter
 def decode_HoppingEvent(data):
     logger.debug(func())

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -329,16 +329,32 @@ def encode_GetReaderConfig(msg):
 
     return data
 
+# 16.1.1
+def decode_GetReaderConfig(data):
+    # XXX ignores CustomParameters
+    logger.debug(func())
+    ret = {}
+
+    # Decode fields
+    (ret['AntennaID'],
+     ret['RequestedData'],
+     ret['GPIPortNum'],
+     ret['GPOPortNum']) = struct.unpack('!HBHH', data)
+
+    logger.debug('GetReaderConfig data: %s', ret)
+    return ret
+
 
 Message_struct['GET_READER_CONFIG'] = {
     'type': 2,
     'fields': [
         'Ver', 'Type', 'ID',
-        'RequestedData',
         'AntennaID',
+        'RequestedData',
         'GPIPortNum',
         'GPOPortNum'
     ],
+    'decode': decode_GetReaderConfig,
     'encode': encode_GetReaderConfig
 }
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -923,6 +923,20 @@ def decode_ROAccessReport(data):
 
     return msg
 
+def encode_ROAccessReport(msg):
+    logger.debug(func())
+    data = b''
+    if 'TagReportData' in msg.keys():
+        for tagdata in msg['TagReportData']:
+            data += encode('TagReportData')(tagdata)
+    if 'RFSurveyReportData' in msg.keys():
+        for rfsurveydata in msg['RFSurveyReportData']:
+            data += encode('RFSurveyReportData')(rfsurveydata)
+    if 'CustomParameter' in msg.keys():
+        for customparam in msg['CustomParameter']:
+            data += encode('CustomParameter')(customparam)
+    logger.debug(func() + "data " + hexlify(data))
+    return data
 
 Message_struct['RO_ACCESS_REPORT'] = {
     'type': 61,
@@ -930,7 +944,8 @@ Message_struct['RO_ACCESS_REPORT'] = {
         'Ver', 'Type', 'ID',
         'TagReportData',
     ],
-    'decode': decode_ROAccessReport
+    'decode': decode_ROAccessReport,
+    'encode': encode_ROAccessReport
 }
 
 
@@ -3041,6 +3056,53 @@ def decode_TagReportData(data):
     logger.debug('par=%s', par)
     return par, data[length:]
 
+def encode_TagReportData(msg):
+    logger.debug(func())
+    msg_header = '!HH'
+    msg_header_len = struct.calcsize(msg_header)
+    data = b''
+    # can only have EPC-96 or EPCData
+    if 'EPC-96' in msg.keys():
+        data += encode('EPC-96')(msg['EPC-96'])
+    else:
+        data += encode('EPCData')(msg['EPCData'])
+    if 'ROSpecID' in msg.keys():
+        data += encode('ROSpecID')(msg['ROSpecID'])
+    if 'SpecIndex' in msg.keys():
+        data += encode('SpecIndex')(msg['SpecIndex'])
+    if 'InventoryParameterSpecID' in msg.keys():
+        data += encode('InventoryParameterSpecID')(msg['InventoryParameterSpecID'])
+    if 'AntennaID' in msg.keys():
+        data += encode('AntennaID')(msg['AntennaID'])
+    if 'PeakRSSI' in msg.keys():
+        data += encode('PeakRSSI')(msg['PeakRSSI'])
+    if 'ChannelIndex' in msg.keys():
+        data += encode('ChannelIndex')(msg['ChannelIndex'])
+    if 'FirstSeenTimeStampUTC' in msg.keys():
+        data += encode('FirstSeenTimeStampUTC')(msg['FirstSeenTimeStampUTC'])
+    if 'FirstSeenTimeStampUptime' in msg.keys():
+        data += encode('FirstSeenTimeStampUptime')(msg['FirstSeenTimeStampUptime'])
+    if 'LastSeenTimeStampUTC' in msg.keys():
+        data += encode('LastSeenTimeStampUTC')(msg['LastSeenTimeStampUTC'])
+    if 'LastSeenTimeStampUptime' in msg.keys():
+        data += encode('LastSeenTimeStampUptime')(msg['LastSeenTimeStampUptime'])
+    if 'TagSeenCount' in msg.keys():
+        data += encode('TagSeenCount')(msg['TagSeenCount'])
+    if 'AirProtocolTagData' in msg.keys():
+        # can be more than one AirProtocolTagData
+        for airprotocol in msg['AirProtocolTagData']:
+            data += encode('AirProtocolTagData')(airprotocol)
+    if 'AccessSpecID' in msg.keys():
+        data += encode('AccessSpecID')(msg['AccessSpecID'])
+    if 'OpSpecResult' in msg.keys():
+        data += encode('OpSpecResult')(msg['OpSpecResult'])
+
+
+    data = struct.pack(msg_header, msg['Type'], msg_header_len + len(data)) + data
+    logger.debug(func() + "data " + hexlify(data))
+    return data
+
+
 
 Message_struct['TagReportData'] = {
     'type': 240,
@@ -3063,8 +3125,10 @@ Message_struct['TagReportData'] = {
         'AccessSpecID',
         'OpSpecResult',
     ],
-    'decode': decode_TagReportData
+    'decode': decode_TagReportData,
+    'encode': encode_TagReportData
 }
+
 
 
 def decode_OpSpecResult(data):
@@ -3250,6 +3314,16 @@ def decode_EPCData(data):
 
     return par, data[length:]
 
+def encode_EPCData(msg):
+    logger.debug(func())
+    msg_header = '!HHH'
+    bin_epc = unhexlify(msg['EPC'])
+    msg_len = struct.calcsize(msg_header) + len(bin_epc)
+    data = struct.pack(msg_header, msg['Type'], msg_len, msg['EPCLengthBits'])
+    data += bin_epc
+    logger.debug(func() + " data " + hexlify(data))
+    return data
+
 
 Message_struct['EPCData'] = {
     'type': 241,
@@ -3258,7 +3332,8 @@ Message_struct['EPCData'] = {
         'EPCLengthBits',
         'EPC'
     ],
-    'decode': decode_EPCData
+    'decode': decode_EPCData,
+    'encode': encode_EPCData
 }
 
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -953,26 +953,32 @@ Message_struct['RO_ACCESS_REPORT'] = {
 def decode_Keepalive(msg):
     return b''
 
+def encode_Keepalive(msg):
+    return b''
 
 Message_struct['KEEPALIVE'] = {
     'type': 62,
     'fields': [
         'Ver', 'Type', 'ID',
     ],
-    'decode': decode_Keepalive
+    'decode': decode_Keepalive,
+    'encode': encode_Keepalive
 }
 
 
 # 16.1.36 KEEPALIVE_ACK
-def encode_KeepaliveAck(msg):
+def decode_KeepaliveAck(msg):
     return b''
 
+def encode_KeepaliveAck(msg):
+    return b''
 
 Message_struct['KEEPALIVE_ACK'] = {
     'type': 72,
     'fields': [
         'Ver', 'Type', 'ID',
     ],
+    'decode': decode_KeepaliveAck,
     'encode': encode_KeepaliveAck
 }
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -1597,11 +1597,11 @@ def encode_GeneralDeviceCapabilities(msg):
                        bytes(msg['ReaderFirmwareVersion']))
     fwversion_bytecount = len(fwversion)
     # CanSetAntennaProperties (C) and HasUTCClockCapability (T) are single bits
-    # using the space  of a !H
-    CTbits = str(msg['CanSetAntennaProperties']) + str(msg['HasUTCClockCapability']) + '00'
+    # using the space of a !H
+    CTbits = str(msg['CanSetAntennaProperties']) + str(msg['HasUTCClockCapability'])
+    CTbits += '00000000000000' # reserved bits.
 
-    data = unhexlify(CTbits)
-    data += struct.pack('!IIH', msg['DeviceManufacturerName'],
+    data = struct.pack('!HIIH', int(CTbits,2), msg['DeviceManufacturerName'],
                         msg['ModelName'], fwversion_bytecount) + fwversion
 
 
@@ -3401,23 +3401,47 @@ Message_struct['ROSpecID'] = {
     'tv_encoded': True,
 }
 
-# 16.2.7.3.11 LastSeenTimestampUTC Parameter
-def encode_LastSeenTimestampUTC(msg):
+def encode_TVTimestamp(msg):
     # TODO this is a general solution for all TV encoded timestamps
     data = struct.pack('!BQ', msg['Type'] | BIT(7), msg['Microseconds'])
     return data
 
+# 16.2.7.3.9 FirsttSeenTimestampUTC Parameter
+Message_struct['FirstSeenTimestampUTC'] = {
+    'type': 2,
+    'fields': [
+        'Type',
+        'Microseconds'
+    ],
+    'encode': encode_TVTimestamp,
+    'tv_encoded': True,
+}
 
+# 16.2.7.3.11 LastSeenTimestampUTC Parameter
 Message_struct['LastSeenTimestampUTC'] = {
     'type': 4,
     'fields': [
         'Type',
         'Microseconds'
     ],
-    'encode': encode_LastSeenTimestampUTC,
+    'encode': encode_TVTimestamp,
     'tv_encoded': True,
 }
 
+# 16.2.7.3.7 PeakRSSI Parameter
+def encode_PeakRSSI(msg):
+    data = struct.pack('!BB', msg['Type'] | BIT(7), msg['PeakRSSI'])
+    return data
+
+Message_struct['PeakRSSI'] = {
+    'type': 6,
+    'fields': [
+        'Type',
+        'PeakRSSI'
+    ],
+    'encode': encode_PeakRSSI,
+    'tv_encoded': True,
+}
 
 # 16.2.7.6.1 HoppingEvent Parameter
 def decode_HoppingEvent(data):

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -415,6 +415,48 @@ def decode_param(data):
 
     return ret, data[parlen:]
 
+def encode_GetReaderConfigResponse(msg):
+    # XXX ignores CustomParameters
+    logger.debug(func())
+    data = encode('LLRPStatus')(msg['LLRPStatus'])
+
+    if 'Identification' in msg.keys():
+        data += encode('Identification')(msg['Identification'])
+
+    if 'AntennaProperties' in msg.keys():
+        data += encode('AntennaProperties')(msg['AntennaProperties'])
+
+    if 'AntennaConfiguration' in msg.keys():
+        data += encode('AntennaConfiguration')(msg['AntennaConfiguration'])
+
+    if 'ReaderEventNotificationSpec' in msg.keys():
+        data += encode('ReaderEventNotificationSpec')(msg['ReaderEventNotificationSpec'])
+
+    if 'ROReportSpec' in msg.keys():
+        data += encode('ROReportSpec')(msg['ROReportSpec'])
+
+    if 'AccessReportSpec' in msg.keys():
+        data += encode('AccessReportSpec')(msg['AccessReportSpec'])
+
+    if 'LLRPConfigurationStateValue' in msg.keys():
+        data += encode('LLRPConfigurationStateValue')(msg['LLRPConfigurationStateValue'])
+
+    if 'KeepAliveSpec' in msg.keys():
+        data += encode('KeepAliveSpec')(msg['KeepAliveSpec'])
+
+    if 'GPIPortCurrentState' in msg.keys():
+        data += encode('GPIPortCurrentState')(msg['GPIPortCurrentState'])
+
+    if 'GPOWriteData' in msg.keys():
+        data += encode('GPOWriteData')(msg['GPOWriteData'])
+
+    if 'EventsAndReports' in msg.keys():
+        data += encode('EventsAndReports')(msg['EventsAndReports'])
+
+    logger.debug('GetReaderConfigResponse data: %s', hexlify(data))
+    return data
+
+
 
 def decode_GetReaderConfigResponse(data):
     msg = LLRPMessageDict()
@@ -460,7 +502,8 @@ Message_struct['GET_READER_CONFIG_RESPONSE'] = {
         'GPOWriteData',
         'EventsAndReports',
     ],
-    'decode': decode_GetReaderConfigResponse
+    'decode': decode_GetReaderConfigResponse,
+    'encode': encode_GetReaderConfigResponse
 }
 
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -763,6 +763,15 @@ def encode_EnableROSpec(msg):
 
     return struct.pack('!I', msgid)
 
+def decode_EnableROSpec(data):
+    logger.debug(func())
+    ret = {}
+    msg_header = '!I'
+    ret['ROSpecID'] = struct.unpack('!I', data)
+
+    logger.debug(ret)
+    return ret
+
 
 Message_struct['ENABLE_ROSPEC'] = {
     'type': 24,
@@ -770,7 +779,8 @@ Message_struct['ENABLE_ROSPEC'] = {
         'Ver', 'Type', 'ID',
         'ROSpecID'
     ],
-    'encode': encode_EnableROSpec
+    'encode': encode_EnableROSpec,
+    'decode': decode_EnableROSpec
 }
 
 
@@ -792,6 +802,12 @@ def decode_EnableROSpecResponse(data):
 
     return msg
 
+def encode_EnableROSpecResponse(msg):
+    logger.debug(func())
+    data = encode('LLRPStatus')(msg['LLRPStatus'])
+    logger.debug('EnableROSpecResponse data: %s', hexlify(data))
+    return data
+
 
 Message_struct['ENABLE_ROSPEC_RESPONSE'] = {
     'type': 34,
@@ -799,7 +815,8 @@ Message_struct['ENABLE_ROSPEC_RESPONSE'] = {
         'Ver', 'Type', 'ID',
         'LLRPStatus'
     ],
-    'decode': decode_EnableROSpecResponse
+    'decode': decode_EnableROSpecResponse,
+    'encode': encode_EnableROSpecResponse
 }
 
 
@@ -1019,6 +1036,10 @@ def decode_CloseConnectionResponse(data):
 
     return msg
 
+def encode_CloseConnectionResponse(msg):
+    logger.debug(func())
+    data = encode('LLRPStatus')(msg['LLRPStatus'])
+    return data
 
 # 16.1.41 CLOSE_CONNECTION_RESPONSE
 Message_struct['CLOSE_CONNECTION_RESPONSE'] = {
@@ -1027,7 +1048,8 @@ Message_struct['CLOSE_CONNECTION_RESPONSE'] = {
         'Ver', 'Type', 'ID',
         'LLRPStatus'
     ],
-    'decode': decode_CloseConnectionResponse
+    'decode': decode_CloseConnectionResponse,
+    'encode': encode_CloseConnectionResponse
 }
 
 

--- a/sllurp/llrp_proto.py
+++ b/sllurp/llrp_proto.py
@@ -3078,14 +3078,14 @@ def encode_TagReportData(msg):
         data += encode('PeakRSSI')(msg['PeakRSSI'])
     if 'ChannelIndex' in msg.keys():
         data += encode('ChannelIndex')(msg['ChannelIndex'])
-    if 'FirstSeenTimeStampUTC' in msg.keys():
-        data += encode('FirstSeenTimeStampUTC')(msg['FirstSeenTimeStampUTC'])
-    if 'FirstSeenTimeStampUptime' in msg.keys():
-        data += encode('FirstSeenTimeStampUptime')(msg['FirstSeenTimeStampUptime'])
-    if 'LastSeenTimeStampUTC' in msg.keys():
-        data += encode('LastSeenTimeStampUTC')(msg['LastSeenTimeStampUTC'])
-    if 'LastSeenTimeStampUptime' in msg.keys():
-        data += encode('LastSeenTimeStampUptime')(msg['LastSeenTimeStampUptime'])
+    if 'FirstSeenTimestampUTC' in msg.keys():
+        data += encode('FirstSeenTimestampUTC')(msg['FirstSeenTimestampUTC'])
+    if 'FirstSeenTimestampUptime' in msg.keys():
+        data += encode('FirstSeenTimestampUptime')(msg['FirstSeenTimestampUptime'])
+    if 'LastSeenTimestampUTC' in msg.keys():
+        data += encode('LastSeenTimestampUTC')(msg['LastSeenTimestampUTC'])
+    if 'LastSeenTimestampUptime' in msg.keys():
+        data += encode('LastSeenTimestampUptime')(msg['LastSeenTimestampUptime'])
     if 'TagSeenCount' in msg.keys():
         data += encode('TagSeenCount')(msg['TagSeenCount'])
     if 'AirProtocolTagData' in msg.keys():

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -124,6 +124,33 @@ class TestReaderEventNotification(unittest.TestCase):
         self.assertEqual(expected_result, llrp_msg.msgbytes)
 
 
+class TestGetSupportedVersion(unittest.TestCase):
+    def test_decode(self):
+        data = binascii.unhexlify('082e0000000a00000001')
+        lmsg = sllurp.llrp.LLRPMessage(msgbytes=data)
+        self.assertEqual(lmsg.getName(), 'GET_SUPPORTED_VERSION')
+
+class TestGetSupportedVersionResponse(unittest.TestCase):
+    def test_encode(self):
+        expected_result = binascii.unhexlify('04380000002d000000010101011f0021'
+                                             '006e00195765206f6e6c792073757070'
+                                             '6f72742076657273696f6e2031')
+        msg_dict = {'GET_SUPPORTED_VERSION_RESPONSE': {
+                            'Ver': 1,
+                            'Type': 56,
+                            'ID': 1,
+                            'CurrentVersion': 1,
+                            'SupportedVersion': 1,
+                            'LLRPStatus': {
+                                'Type': 287,
+                                'StatusCode': 'UnsupportedVersion',
+                                'ErrorDescription': 'We only support version 1',
+                            }
+                    }}
+        llrp_msg = sllurp.llrp.LLRPMessage(msgdict=msg_dict)
+        self.assertEqual(expected_result, llrp_msg.msgbytes)
+
+
 class TestDecodeROAccessReport (unittest.TestCase):
     _r = """
     043d0000002c4095892f00f000228d3005fb63ac1f3841ec88046781000186ce820004ec2ea8


### PR DESCRIPTION
This patch continues the work adding some additional support for protocol calls that occur early
in the connection between LLRP clients and servers.

new methods in llrp_proto:
* decode_GetReaderCapabilities
* encode_LLRPStatus
* encode_FieldError
* encode_ParameterError
* decode_getSupportedVersion
* encode_getSupportedVersionResponse
* encode_GetReaderCapabilitiesResponse
* encode_GeneralDeviceCapabilities
* decode_SetReaderConfig
* encode_SetReaderConfigResponse
* decode_GetROSpecs
* decode DeleteAccessSpec
* encode_DeleteAcessSpecResponse
* decode_DeleteROSpec
* encode_DeleteROSpecResponse
* decode_AddROSpec

Adds a test case for decoding GetSupportedVersion using data captured from an in-production client.

