### PR TITLE
PR: new cli command to display reader capabilities

### DIFF
--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -8,6 +8,7 @@ import click
 from . import __version__
 from . import log as loggie
 from .verb import reset as _reset
+from .verb import capabilities as _capabilities
 from .verb import inventory as _inventory
 from .verb import log as _log
 from .verb import access as _access
@@ -169,3 +170,15 @@ def reset(host, port):
     Args = namedtuple('Args', ['host', 'port'])
     args = Args(host=host, port=port)
     _reset.main(args)
+
+
+@cli.command()
+@click.argument('host', type=str, nargs=-1)
+@click.option('-p', '--port', type=int, default=5084)
+def capabilities(host, port):
+    Args = namedtuple('Args', ['host', 'port'])
+    args = Args(host=host, port=port)
+    _capabilities.main(args)
+
+
+

--- a/sllurp/cli.py
+++ b/sllurp/cli.py
@@ -179,6 +179,3 @@ def capabilities(host, port):
     Args = namedtuple('Args', ['host', 'port'])
     args = Args(host=host, port=port)
     _capabilities.main(args)
-
-
-

--- a/sllurp/verb/access.py
+++ b/sllurp/verb/access.py
@@ -5,8 +5,8 @@ import pprint
 import sys
 
 from sllurp.util import monotonic
-from sllurp.llrp import LLRPReaderConfig, LLRPReaderClient, LLRPReaderState, C1G2Read, C1G2Write
-
+from sllurp.llrp import (LLRPReaderConfig, LLRPReaderClient, LLRPReaderState,
+                         C1G2Read, C1G2Write)
 from sllurp.log import get_logger
 
 start_time = None
@@ -21,17 +21,14 @@ def finish_cb(_):
     # stop runtime measurement to determine rates
     runTime = monotonic() - start_time
 
-    logger.info("total # of tags seen: %d (%d tags/second)", tagReport, tagReport / runTime)
+    logger.info('total # of tags seen: %d (%d tags/second)', tagReport,
+                tagReport/runTime)
 
 
 def access_cb(reader, state):
     if args.read_words:
-        opspec = C1G2Read(
-            AccessPassword=args.access_password,
-            MB=args.mb,
-            WordPtr=args.word_ptr,
-            WordCount=args.read_words,
-        )
+        opspec = C1G2Read(AccessPassword=args.access_password, MB=args.mb,
+                          WordPtr=args.word_ptr, WordCount=args.read_words)
     elif args.write_words:
         if sys.version_info.major < 3:
             data = sys.stdin.read(args.write_words * 2)
@@ -39,13 +36,10 @@ def access_cb(reader, state):
             # bytes
             data = sys.stdin.buffer.read(args.write_words * 2)
 
-        opspec = C1G2Write(
-            AccessPassword=args.access_password,
-            MB=args.mb,
-            WordPtr=args.word_ptr,
-            WriteDataWordCount=args.write_words,
-            WriteData=data,
-        )
+        opspec = C1G2Write(AccessPassword=args.access_password, MB=args.mb,
+                           WordPtr=args.word_ptr,
+                           WriteDataWordCount=args.write_words,
+                           WriteData=data)
     else:
         # Unexpected situation
         return
@@ -53,16 +47,17 @@ def access_cb(reader, state):
     return reader.start_access_spec(opspec, stop_after_count=args.count)
 
 
+
 def tag_report_cb(reader, tags):
     """Function to run each time the reader reports seeing tags."""
     global tagReport
     if len(tags):
-        logger.info("saw tag(s): %s", pprint.pformat(tags))
+        logger.info('saw tag(s): %s', pprint.pformat(tags))
     else:
-        logger.info("no tags seen")
+        logger.info('no tags seen')
         return
     for tag in tags:
-        tagReport += tag["TagSeenCount"]
+        tagReport += tag['TagSeenCount']
         if "OpSpecResult" in tag:
             # copy the binary data to the standard output stream
             data = tag["OpSpecResult"].get("ReadData")
@@ -70,7 +65,7 @@ def tag_report_cb(reader, tags):
                 if sys.version_info.major < 3:
                     sys.stdout.write(data)
                 else:
-                    sys.stdout.buffer.write(data)  # bytes
+                    sys.stdout.buffer.write(data) # bytes
                 logger.debug("hex data: %s", binascii.hexlify(data))
 
 
@@ -80,14 +75,15 @@ def main(main_args):
     args = main_args
 
     if not args.host:
-        logger.info("No readers specified.")
+        logger.info('No readers specified.')
         return 0
 
     if not args.read_words and not args.write_words:
-        logger.info("Error: Either --read-words or --write-words has to be" " chosen.")
+        logger.info("Error: Either --read-words or --write-words has to be"
+                    " chosen.")
         return 0
 
-    enabled_antennas = [int(x.strip()) for x in args.antennas.split(",")]
+    enabled_antennas = [int(x.strip()) for x in args.antennas.split(',')]
 
     factory_args = dict(
         report_every_n_tags=args.every_n,
@@ -100,23 +96,23 @@ def main(main_args):
         start_inventory=True,
         disconnect_when_done=True,
         tag_content_selector={
-            "EnableROSpecID": False,
-            "EnableSpecIndex": False,
-            "EnableInventoryParameterSpecID": False,
-            "EnableAntennaID": True,
-            "EnableChannelIndex": False,
-            "EnablePeakRSSI": True,
-            "EnableFirstSeenTimestamp": False,
-            "EnableLastSeenTimestamp": True,
-            "EnableTagSeenCount": True,
-            "EnableAccessSpecID": True,
-        },
+            'EnableROSpecID': False,
+            'EnableSpecIndex': False,
+            'EnableInventoryParameterSpecID': False,
+            'EnableAntennaID': True,
+            'EnableChannelIndex': False,
+            'EnablePeakRSSI': True,
+            'EnableFirstSeenTimestamp': False,
+            'EnableLastSeenTimestamp': True,
+            'EnableTagSeenCount': True,
+            'EnableAccessSpecID': True,
+        }
     )
 
     reader_clients = []
     for host in args.host:
-        if ":" in host:
-            host, port = host.split(":", 1)
+        if ':' in host:
+            host, port = host.split(':', 1)
             port = int(port)
         else:
             port = args.port
@@ -160,4 +156,6 @@ def main(main_args):
                 except:
                     logger.exception("Error during disconnect. Ignoring...")
                     pass
+
+
 

--- a/sllurp/verb/access.py
+++ b/sllurp/verb/access.py
@@ -5,9 +5,8 @@ import pprint
 import sys
 
 from sllurp.util import monotonic
-from sllurp.llrp import (LLRPReaderConfig, LLRPReaderClient, LLRPReaderState,
-                         C1G2Read, C1G2Write)
-from sllurp.llrp_proto import Modulation_DefaultTari
+from sllurp.llrp import LLRPReaderConfig, LLRPReaderClient, LLRPReaderState, C1G2Read, C1G2Write
+
 from sllurp.log import get_logger
 
 start_time = None
@@ -22,14 +21,17 @@ def finish_cb(_):
     # stop runtime measurement to determine rates
     runTime = monotonic() - start_time
 
-    logger.info('total # of tags seen: %d (%d tags/second)', tagReport,
-                tagReport/runTime)
+    logger.info("total # of tags seen: %d (%d tags/second)", tagReport, tagReport / runTime)
 
 
 def access_cb(reader, state):
     if args.read_words:
-        opspec = C1G2Read(AccessPassword=args.access_password, MB=args.mb,
-                          WordPtr=args.word_ptr, WordCount=args.read_words)
+        opspec = C1G2Read(
+            AccessPassword=args.access_password,
+            MB=args.mb,
+            WordPtr=args.word_ptr,
+            WordCount=args.read_words,
+        )
     elif args.write_words:
         if sys.version_info.major < 3:
             data = sys.stdin.read(args.write_words * 2)
@@ -37,10 +39,13 @@ def access_cb(reader, state):
             # bytes
             data = sys.stdin.buffer.read(args.write_words * 2)
 
-        opspec = C1G2Write(AccessPassword=args.access_password, MB=args.mb,
-                           WordPtr=args.word_ptr,
-                           WriteDataWordCount=args.write_words,
-                           WriteData=data)
+        opspec = C1G2Write(
+            AccessPassword=args.access_password,
+            MB=args.mb,
+            WordPtr=args.word_ptr,
+            WriteDataWordCount=args.write_words,
+            WriteData=data,
+        )
     else:
         # Unexpected situation
         return
@@ -48,17 +53,16 @@ def access_cb(reader, state):
     return reader.start_access_spec(opspec, stop_after_count=args.count)
 
 
-
 def tag_report_cb(reader, tags):
     """Function to run each time the reader reports seeing tags."""
     global tagReport
     if len(tags):
-        logger.info('saw tag(s): %s', pprint.pformat(tags))
+        logger.info("saw tag(s): %s", pprint.pformat(tags))
     else:
-        logger.info('no tags seen')
+        logger.info("no tags seen")
         return
     for tag in tags:
-        tagReport += tag['TagSeenCount']
+        tagReport += tag["TagSeenCount"]
         if "OpSpecResult" in tag:
             # copy the binary data to the standard output stream
             data = tag["OpSpecResult"].get("ReadData")
@@ -66,7 +70,7 @@ def tag_report_cb(reader, tags):
                 if sys.version_info.major < 3:
                     sys.stdout.write(data)
                 else:
-                    sys.stdout.buffer.write(data) # bytes
+                    sys.stdout.buffer.write(data)  # bytes
                 logger.debug("hex data: %s", binascii.hexlify(data))
 
 
@@ -76,15 +80,14 @@ def main(main_args):
     args = main_args
 
     if not args.host:
-        logger.info('No readers specified.')
+        logger.info("No readers specified.")
         return 0
 
     if not args.read_words and not args.write_words:
-        logger.info("Error: Either --read-words or --write-words has to be"
-                    " chosen.")
+        logger.info("Error: Either --read-words or --write-words has to be" " chosen.")
         return 0
 
-    enabled_antennas = [int(x.strip()) for x in args.antennas.split(',')]
+    enabled_antennas = [int(x.strip()) for x in args.antennas.split(",")]
 
     factory_args = dict(
         report_every_n_tags=args.every_n,
@@ -97,23 +100,23 @@ def main(main_args):
         start_inventory=True,
         disconnect_when_done=True,
         tag_content_selector={
-            'EnableROSpecID': False,
-            'EnableSpecIndex': False,
-            'EnableInventoryParameterSpecID': False,
-            'EnableAntennaID': True,
-            'EnableChannelIndex': False,
-            'EnablePeakRSSI': True,
-            'EnableFirstSeenTimestamp': False,
-            'EnableLastSeenTimestamp': True,
-            'EnableTagSeenCount': True,
-            'EnableAccessSpecID': True,
-        }
+            "EnableROSpecID": False,
+            "EnableSpecIndex": False,
+            "EnableInventoryParameterSpecID": False,
+            "EnableAntennaID": True,
+            "EnableChannelIndex": False,
+            "EnablePeakRSSI": True,
+            "EnableFirstSeenTimestamp": False,
+            "EnableLastSeenTimestamp": True,
+            "EnableTagSeenCount": True,
+            "EnableAccessSpecID": True,
+        },
     )
 
     reader_clients = []
     for host in args.host:
-        if ':' in host:
-            host, port = host.split(':', 1)
+        if ":" in host:
+            host, port = host.split(":", 1)
             port = int(port)
         else:
             port = args.port
@@ -157,6 +160,4 @@ def main(main_args):
                 except:
                     logger.exception("Error during disconnect. Ignoring...")
                     pass
-
-
 

--- a/sllurp/verb/capabilities.py
+++ b/sllurp/verb/capabilities.py
@@ -1,4 +1,4 @@
-"""Reset command.
+"""Capabilities command.
 """
 
 import logging

--- a/sllurp/verb/capabilities.py
+++ b/sllurp/verb/capabilities.py
@@ -1,0 +1,71 @@
+"""Reset command.
+"""
+
+import logging
+import pprint
+from sllurp.llrp import LLRPReaderConfig, LLRPReaderClient, LLRPReaderState
+from sllurp.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def shutdown(reader, state):
+    host, port = reader.get_peername()
+    logger.info('Shutting down reader %s:%d', host, port)
+    reader.disconnect()
+
+def main(args):
+    if not args.host:
+        logger.info('No readers specified.')
+        return 0
+
+    factory_args = {
+        'start_inventory': False,
+        'reset_on_connect': False,
+    }
+
+    reader_clients = []
+    for host in args.host:
+        if ':' in host:
+            host, port = host.split(':', 1)
+            port = int(port)
+        else:
+            port = args.port
+
+        config = LLRPReaderConfig(factory_args)
+        reader = LLRPReaderClient(host, port, config, timeout=3)
+        reader.add_state_callback(LLRPReaderState.STATE_CONNECTED, shutdown)
+        # FYI, the reader connection is really finished and idle in the state
+        # STATE_SENT_SET_CONFIG just before inventory because of the big state
+        # machine. But for "reset", stopping after STATE_CONNECTED is enough
+        reader_clients.append(reader)
+
+    for reader in reader_clients:
+        host, port = reader.get_peername()
+        try:
+            reader.connect()
+        except:
+            logger.error("Failed to connect to %s:%d. Skipping...",
+                         host, port)
+
+    while True:
+        try:
+            # Join all threads using a timeout so it doesn't block
+            # Filter out threads which have been joined or are None
+            alive_readers = [reader for reader in reader_clients if reader.is_alive()]
+            if not alive_readers:
+                break
+            for reader in alive_readers:
+                reader.join(1)
+                host, port = reader.get_peername()
+                logger.info('Capabilities of the reader %s:%d: \n%s' % (host, port, pprint.pformat(reader.llrp.capabilities)))
+            
+        except (KeyboardInterrupt, SystemExit):
+            # catch ctrl-C and stop inventory before disconnecting
+            logger.info("Exit detected! Stopping readers...")
+            for reader in reader_clients:
+                try:
+                    reader.disconnect()
+                except:
+                    logger.exception("Error during disconnect. Ignoring...")
+                    pass

--- a/sllurp/verb/capabilities.py
+++ b/sllurp/verb/capabilities.py
@@ -17,7 +17,7 @@ def shutdown(reader, state):
 def main(args):
     if not args.host:
         logger.info('No readers specified.')
-        return 0
+        return 1
 
     factory_args = {
         'start_inventory': False,

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -8,7 +8,6 @@ import time
 
 from sllurp.util import monotonic
 from sllurp.llrp import LLRPReaderConfig, LLRPReaderClient, LLRPReaderState
-
 from sllurp.log import get_logger
 from sllurp.log import is_general_debug_enabled, set_general_debug
 
@@ -17,11 +16,10 @@ start_time = None
 numtags = 0
 logger = get_logger(__name__)
 
-
 def finish_cb(reader):
     runtime = monotonic() - start_time
-    logger.info("total # of tags seen: %d (%d tags/second)", numtags, numtags / runtime)
-
+    logger.info('total # of tags seen: %d (%d tags/second)', numtags,
+                numtags/runtime)
 
 def inventory_start_cb(reader, state):
     global start_time
@@ -32,22 +30,21 @@ def tag_report_cb(reader, tags):
     """Function to run each time the reader reports seeing tags."""
     global numtags
     if len(tags):
-        logger.info("saw tag(s): %s", pprint.pformat(tags))
+        logger.info('saw tag(s): %s', pprint.pformat(tags))
         for tag in tags:
-            numtags += tag["TagSeenCount"]
+            numtags += tag['TagSeenCount']
     else:
-        logger.info("no tags seen")
+        logger.info('no tags seen')
         return
-
 
 def main(args):
     global start_time
 
     if not args.host:
-        logger.info("No readers specified.")
+        logger.info('No readers specified.')
         return 0
 
-    enabled_antennas = [int(x.strip()) for x in args.antennas.split(",")]
+    enabled_antennas = [int(x.strip()) for x in args.antennas.split(',')]
 
     factory_args = dict(
         duration=args.time,
@@ -63,38 +60,42 @@ def main(args):
         reconnect=args.reconnect,
         tag_filter_mask=args.tag_filter_mask,
         tag_content_selector={
-            "EnableROSpecID": False,
-            "EnableSpecIndex": False,
-            "EnableInventoryParameterSpecID": False,
-            "EnableAntennaID": False,
-            "EnableChannelIndex": True,
-            "EnablePeakRSSI": False,
-            "EnableFirstSeenTimestamp": False,
-            "EnableLastSeenTimestamp": True,
-            "EnableTagSeenCount": True,
-            "EnableAccessSpecID": False,
-            "C1G2EPCMemorySelector": {"EnableCRC": False, "EnablePCBits": False},
+            'EnableROSpecID': False,
+            'EnableSpecIndex': False,
+            'EnableInventoryParameterSpecID': False,
+            'EnableAntennaID': False,
+            'EnableChannelIndex': True,
+            'EnablePeakRSSI': False,
+            'EnableFirstSeenTimestamp': False,
+            'EnableLastSeenTimestamp': True,
+            'EnableTagSeenCount': True,
+            'EnableAccessSpecID': False,
+            'C1G2EPCMemorySelector': {
+                'EnableCRC': False,
+                'EnablePCBits': False,
+            }
         },
         impinj_extended_configuration=args.impinj_extended_configuration,
         impinj_search_mode=args.impinj_search_mode,
         impinj_tag_content_selector=None,
     )
     if args.impinj_reports:
-        factory_args["impinj_tag_content_selector"] = {
-            "EnableRFPhaseAngle": True,
-            "EnablePeakRSSI": True,
-            "EnableRFDopplerFrequency": True,
+        factory_args['impinj_tag_content_selector'] = {
+            'EnableRFPhaseAngle': True,
+            'EnablePeakRSSI': True,
+            'EnableRFDopplerFrequency': True
         }
     if args.impinj_fixed_freq:
-        factory_args["impinj_fixed_frequency_param"] = {
-            "FixedFrequencyMode": 2,
-            "ChannelListIndex": [1],
+        factory_args['impinj_fixed_frequency_param'] = {
+            'FixedFrequencyMode': 2,
+            'ChannelListIndex': [1]
         }
+
 
     reader_clients = []
     for host in args.host:
-        if ":" in host:
-            host, port = host.split(":", 1)
+        if ':' in host:
+            host, port = host.split(':', 1)
             port = int(port)
         else:
             port = args.port
@@ -105,6 +106,7 @@ def main(args):
         reader.add_tag_report_callback(tag_report_cb)
         reader.add_state_callback(LLRPReaderState.STATE_INVENTORYING, inventory_start_cb)
         reader_clients.append(reader)
+
 
     start_time = monotonic()
     try:

--- a/sllurp/verb/inventory.py
+++ b/sllurp/verb/inventory.py
@@ -8,7 +8,7 @@ import time
 
 from sllurp.util import monotonic
 from sllurp.llrp import LLRPReaderConfig, LLRPReaderClient, LLRPReaderState
-from sllurp.llrp_proto import Modulation_DefaultTari
+
 from sllurp.log import get_logger
 from sllurp.log import is_general_debug_enabled, set_general_debug
 
@@ -17,10 +17,11 @@ start_time = None
 numtags = 0
 logger = get_logger(__name__)
 
+
 def finish_cb(reader):
     runtime = monotonic() - start_time
-    logger.info('total # of tags seen: %d (%d tags/second)', numtags,
-                numtags/runtime)
+    logger.info("total # of tags seen: %d (%d tags/second)", numtags, numtags / runtime)
+
 
 def inventory_start_cb(reader, state):
     global start_time
@@ -31,21 +32,22 @@ def tag_report_cb(reader, tags):
     """Function to run each time the reader reports seeing tags."""
     global numtags
     if len(tags):
-        logger.info('saw tag(s): %s', pprint.pformat(tags))
+        logger.info("saw tag(s): %s", pprint.pformat(tags))
         for tag in tags:
-            numtags += tag['TagSeenCount']
+            numtags += tag["TagSeenCount"]
     else:
-        logger.info('no tags seen')
+        logger.info("no tags seen")
         return
+
 
 def main(args):
     global start_time
 
     if not args.host:
-        logger.info('No readers specified.')
+        logger.info("No readers specified.")
         return 0
 
-    enabled_antennas = [int(x.strip()) for x in args.antennas.split(',')]
+    enabled_antennas = [int(x.strip()) for x in args.antennas.split(",")]
 
     factory_args = dict(
         duration=args.time,
@@ -61,42 +63,38 @@ def main(args):
         reconnect=args.reconnect,
         tag_filter_mask=args.tag_filter_mask,
         tag_content_selector={
-            'EnableROSpecID': False,
-            'EnableSpecIndex': False,
-            'EnableInventoryParameterSpecID': False,
-            'EnableAntennaID': False,
-            'EnableChannelIndex': True,
-            'EnablePeakRSSI': False,
-            'EnableFirstSeenTimestamp': False,
-            'EnableLastSeenTimestamp': True,
-            'EnableTagSeenCount': True,
-            'EnableAccessSpecID': False,
-            'C1G2EPCMemorySelector': {
-                'EnableCRC': False,
-                'EnablePCBits': False,
-            }
+            "EnableROSpecID": False,
+            "EnableSpecIndex": False,
+            "EnableInventoryParameterSpecID": False,
+            "EnableAntennaID": False,
+            "EnableChannelIndex": True,
+            "EnablePeakRSSI": False,
+            "EnableFirstSeenTimestamp": False,
+            "EnableLastSeenTimestamp": True,
+            "EnableTagSeenCount": True,
+            "EnableAccessSpecID": False,
+            "C1G2EPCMemorySelector": {"EnableCRC": False, "EnablePCBits": False},
         },
         impinj_extended_configuration=args.impinj_extended_configuration,
         impinj_search_mode=args.impinj_search_mode,
         impinj_tag_content_selector=None,
     )
     if args.impinj_reports:
-        factory_args['impinj_tag_content_selector'] = {
-            'EnableRFPhaseAngle': True,
-            'EnablePeakRSSI': True,
-            'EnableRFDopplerFrequency': True
+        factory_args["impinj_tag_content_selector"] = {
+            "EnableRFPhaseAngle": True,
+            "EnablePeakRSSI": True,
+            "EnableRFDopplerFrequency": True,
         }
     if args.impinj_fixed_freq:
-        factory_args['impinj_fixed_frequency_param'] = {
-            'FixedFrequencyMode': 2,
-            'ChannelListIndex': [1]
+        factory_args["impinj_fixed_frequency_param"] = {
+            "FixedFrequencyMode": 2,
+            "ChannelListIndex": [1],
         }
-
 
     reader_clients = []
     for host in args.host:
-        if ':' in host:
-            host, port = host.split(':', 1)
+        if ":" in host:
+            host, port = host.split(":", 1)
             port = int(port)
         else:
             port = args.port
@@ -107,7 +105,6 @@ def main(args):
         reader.add_tag_report_callback(tag_report_cb)
         reader.add_state_callback(LLRPReaderState.STATE_INVENTORYING, inventory_start_cb)
         reader_clients.append(reader)
-
 
     start_time = monotonic()
     try:


### PR DESCRIPTION
I created a command entry point to display capabilities of the reader (suggestion from #142).
Can be used like that: 
```
sllurp capabilities 192.168.1.5 # ask and display the reader capabilities
```

